### PR TITLE
Draft a Docker build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+libki.log
+libki.pid
+libki.status
+libki_local.conf
+libki_server.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM perl:5.24
+
+RUN apt-get update && apt-get -y install anacron cpanminus cron rsyslog
+
+COPY cpanfile /tmp/
+RUN cpanm -n --installdeps /tmp/
+
+COPY docker/cron.minute /etc/cron.d/libkiminutes
+COPY docker/cron.daily /etc/cron.daily/libkidailyreset
+COPY docker/startup.sh /etc/
+
+RUN chmod 644 /etc/cron.d/libkiminutes && chmod 755 /etc/cron.daily/libkidailyreset /etc/startup.sh
+
+CMD ["/etc/startup.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+---
+version: '2'
+services:
+  mysql:
+    container_name: libki_mysql
+    environment:
+      - MYSQL_PASSWORD=libkidb
+      - MYSQL_USER=libkidb
+      - MYSQL_DATABASE=libki
+      - MYSQL_ROOT_PASSWORD=rootdb
+    image: mysql
+    ports:
+      - '3306'
+    volumes:
+      - /var/libki/mysql:/var/lib/mysql
+  libki:
+    build: ./
+    container_name: libki
+    depends_on:
+      - mysql
+    environment:
+      - LIBKI_USERNAME=admin
+      - LIBKI_PASSWORD=libkiadmin
+    ports:
+      - '8080:3000'
+    volumes:
+      - .:/libki

--- a/docker/cron.daily
+++ b/docker/cron.daily
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+/usr/local/bin/perl /libki/script/cronjobs/libki_nightly.pl && printf "$(date +"%Y-%m-%d %H:%M:%S")\tCRON libki_nightly.pl\n" >> /libki/libki.log
+

--- a/docker/cron.minute
+++ b/docker/cron.minute
@@ -1,0 +1,2 @@
+* * * * * root /usr/local/bin/perl /libki/script/cronjobs/libki.pl
+# decrease the minutes

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+printf "\n$(date +"%Y-%m-%d %H:%M:%S")\tcontainer starting\n"
+printf "$(date +"%Y-%m-%d %H:%M:%S")\tcron starting\n"
+service rsyslog start
+service cron restart
+service anacron start
+#cron -f &
+printf "$(date +"%Y-%m-%d %H:%M:%S")\tweb server\n"
+start_server --port 3000 \
+             --pid-file /libki/libki.pid \
+             --status-file /libki/libki.status \
+             --log-file /libki/libki_server.log \
+             -- plackup \
+             -I /libki/lib \
+             -s Starman \
+             --workers 2 \
+             --max-requests 50000 \
+             -E production \
+             -a /libki/libki.psgi

--- a/log4perl.conf
+++ b/log4perl.conf
@@ -1,7 +1,7 @@
 log4perl.rootLogger			= DEBUG, LOGFILE, SCREEN
 
 log4perl.appender.LOGFILE		= Log::Log4perl::Appender::File
-log4perl.appender.LOGFILE.filename	= /home/libki/libki-server/libki.log
+log4perl.appender.LOGFILE.filename	= /var/log/libki.log
 log4perl.appender.LOGFILE.mode		= append
 log4perl.appender.LOGFILE.layout	= PatternLayout
 log4perl.appender.LOGFILE.layout.ConversionPattern=[%d] [libki] [%p] %m%n


### PR DESCRIPTION
  Create a Dockerfile based on the perl:5.24 image.  Install the server
dependencies.  Add the cron jobs.  And then launch the startup script,
which will launch the server and launch the cron and rsyslog services.

  Include that build in a Docker Compose application that also includes
a MySQL container that points to a persistent volume.  This container
currently assumes that the database has already been initialized
properly.

  Add some git ignore rules for the files that are temporarily created
by the running server.

  Move the libki.log file in log4perl.conf from
`/home/libki/libki-server/libki.log` to the more generic
`/var/log/libki.log`.