### PR TITLE
Added ntp package in manual installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ adduser libki
 ### Install needed packages
 
 ```bash
-apt-get install curl perl git make build-essential unzip mysql-server pwgen -y
+apt-get install curl perl git make build-essential unzip mysql-server pwgen ntp -y
 ```
 
 ### Download and install Libki and needed Perl modules


### PR DESCRIPTION
Short edit of the readme, where I added ntp in the apt-get line. The reason is that my server's clock has lagged a couple of minutes behind, which was messing with the closing hours. This fixes that. 

I didn't bother with adding anything about the ntp configuration and choosing server, since the debian pool servers usually works perfectly and I want to keep the install instructions as simple as possible.