### PR TITLE
Added @INC to the cronjob files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Please, make [pull requests](https://help.github.com/articles/about-pull-request
 
 ## Manual Installation
 
-This guide is tested on Debian Stretch (9.3) and Ubuntu Server 16.04.3.
+This guide is tested on Debian Jessie (8.10).
 
 ### Login as root
 
@@ -39,7 +39,7 @@ apt-get upgrade
 
 Then, we'll install the needed packages.
 ```bash
-apt-get install curl perl git make build-essential unzip mysql-server pwgen ntp libmysqlclient-dev -y
+apt-get install curl perl git make build-essential unzip mysql-server pwgen ntp -y
 ```
 
 ### Download and install Libki and needed Perl modules

--- a/cron
+++ b/cron
@@ -1,2 +1,2 @@
-* * * * *	libki	source /home/libki/.bashrc; perl -X /home/libki/libki-server/script/cronjobs/libki.pl
-0 0 * * *	libki	suorce /home/libki/.bashrc; perl -X /home/libki/libki-server/script/cronjobs/libki_nightly.pl
+* * * * * perl -X /home/libki/libki-server/script/cronjobs/libki.pl
+0 0 * * * perl -X /home/libki/libki-server/script/cronjobs/libki_nightly.pl

--- a/script/cronjobs/libki.pl
+++ b/script/cronjobs/libki.pl
@@ -3,6 +3,8 @@
 use strict;
 use warnings;
 
+use lib '/home/libki/perl5/lib/perl5';
+
 use Env;
 use Config::JFDI;
 use DateTime::Format::MySQL;

--- a/script/cronjobs/libki_nightly.pl
+++ b/script/cronjobs/libki_nightly.pl
@@ -1,5 +1,7 @@
 #!/usr/bin/perl
 
+use lib '/home/libki/perl5/lib/perl5';
+
 use Modern::Perl;
 
 use Config::JFDI;


### PR DESCRIPTION
Remember that ugly problem we had a while back where cron refused to include local::lib in $PATH? Well, it's back. So I added a quick fix so stuff runs, at least. I'll update this asap so it's a relative path, not depending on a ```libki``` user.

Also, I'm having trouble setting up a working server on Debian Stretch and Ubuntu Server 16.04.3 right now, so the manual installation guide again states that you need Debian Jessie. I'll look into this soon as well.