### PR TITLE
Altered table 'users' field 'notes' to allow NULL.

### DIFF
--- a/installer/versions/2.03.00.00/users-notes-null.sql
+++ b/installer/versions/2.03.00.00/users-notes-null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE 'users' MODIFY COLUMN 'notes' text;


### PR DESCRIPTION
In order to properly work with mysqldump and later importing the dump, 'notes' can't be NOT NULL, since create_user.pl won't give it a value. 