### PR TITLE
Added programs for backing up and restoring the database

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,8 @@ chown libki:libki /home/libki/libki-server -R
 cpanm -n Module::Install
 cpanm -n --installdeps .
 
+echo 'export PERL5LIB=$PERL5LIB:/home/libki/libki-server/lib' >> ~/.bashrc
+echo 'export PERL5LIB=$PERL5LIB:/home/libki/libki-server/lib' >> /home/libki/.bashrc
 export PERL5LIB=$PERL5LIB:/home/libki/libki-server/lib
 
 # Create log files, change ownership to libki
@@ -163,6 +165,10 @@ if [[ $PROXYCHECKER = "yes" ]]; then
   service apache2 start
 fi
 
+# Copies the backup and the restore programs to /usr/local/bin
+cp script/utilities/backup_db.sh /usr/local/bin/libki-backup
+cp script/utilities/restore_db.sh /usr/local/bin/libki-restore
+
 # Report all settings
 echo
 echo "Congratulations!"
@@ -185,3 +191,5 @@ echo "Your log files are located in /var/log/libki/"
 echo
 echo "Your server can be reached on the following address:"
 echo "$URL"
+
+exit 0

--- a/script/utilities/backup_db.sh
+++ b/script/utilities/backup_db.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+echo
+
+### VARIABLES, TEMP FILES AND FUNCTIONS
+
+# Date and time in format YYMMDD_HH.MM
+DATE=$(date +%y%m%d_%H.%M)
+
+# Fetch password from libki_local.conf
+PASSLINE=$(sed -n '5p' < /home/libki/libki-server/libki_local.conf)
+
+PASSWORD=${PASSLINE:18:-1}
+
+# Creates a temp config file to suppress warning messages
+{
+  echo "[client"]
+  echo "user = libki"
+  echo "password = $PASSWORD"
+} >> /home/libki/mysql_tmp.cnf
+
+# Functions
+
+function helptext {
+  echo "Welcome to the Libki Server Database Backup."
+  echo
+  echo "This will restore backup your database."
+  echo
+  echo "If used without a flag, the program will run in an interactive default."
+  echo
+  echo "Flags"
+  echo
+  echo "    --help, -h        This help text"
+  echo "    --silent, -s      Run the program non-interactively."
+  echo "                      This is for when running automatic backups."
+  echo
+}
+
+### FLAG HANDLING ###
+
+while [ ! $# -eq 0 ]; do
+  case "$1" in
+    --help | -h)
+      helptext
+      exit
+      ;;
+    --silent | -s)
+      # See program code further down for comments
+      mkdir -p /home/libki/backups
+      mysqldump --defaults-extra-file=/home/libki/mysql_tmp.cnf libki > /home/libki/backups/db_$DATE.sql
+      rm /home/libki/mysql_tmp.cnf
+      exit
+      ;;
+    *)
+      echo "Welcome to the Libki Server Database Backup."
+      echo
+      echo "Use --help for instructions."
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+### PROGRAM ###
+
+echo "Welcome to the Libki Server backup program"
+echo
+echo "It's best to run this before opening hours so all accounts have their correct time allotment."
+echo
+echo "Do you wish to make a backup of your current server?"
+
+select ANSWER in "Yes" "No"; do
+  case "$ANSWER" in
+    Yes )
+      break
+    ;;
+    No )
+      exit 1
+    ;;
+    * )
+      echo
+      echo "You must choose 1 (Yes) or 2 (No)"
+      continue
+  esac
+  break
+done
+
+
+# Creates a backup folder if it doesn't exist
+mkdir -p /home/libki/backups
+
+# Makes the backup
+mysqldump --defaults-extra-file=/home/libki/mysql_tmp.cnf libki > /home/libki/backups/db_$DATE.sql
+
+# Deletes the temp file
+rm /home/libki/mysql_tmp.cnf
+
+echo
+echo "Your database has been backed up to /home/libki/backups/libki_db_backup_$DATE.sql"
+echo
+
+exit 0

--- a/script/utilities/restore_db.sh
+++ b/script/utilities/restore_db.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+echo
+
+### VARIABLES, TEMP FILES AND FUNCTIONS ###
+
+# Fetch password from libki_local.conf
+
+PASSLINE=$(sed -n '5p' < /home/libki/libki-server/libki_local.conf)
+
+PASSWORD=${PASSLINE:18:-1}
+
+# Creates a temp config file to suppress warning messages
+{
+  echo "[client"]
+  echo "user = libki"
+  echo "password = $PASSWORD"
+} >> /home/libki/mysql_tmp.cnf
+
+# Create temp mysql script to avoid user input
+{
+  echo "DROP DATABASE libki;"
+  echo "CREATE DATABASE libki;"
+} >> /home/libki/mysql_tmp_script.sql
+
+# Functions
+
+function helptext {
+  echo "Welcome to the Libki Server Database Restorer."
+  echo
+  echo "This will restore your database to the backup you choose."
+  echo "It will therefore also delete your current database."
+  echo
+  echo "Usage:"
+  echo "Run the program with the database backup of your choice"
+  echo "as an argument."
+  echo
+  echo "Example: libki-restore /home/libki/backups/db_170422_17.53.sql"
+  echo
+  echo "Flags"
+  echo "    -h, --help        This help text"
+  echo
+}
+
+# If no file was passed as an argument
+if [ -z "$1" ]; then
+  echo "Welcome to the Libki Server Database Restorer."
+  echo
+  echo "Use --help for instructions."
+  echo
+  exit 1
+fi
+
+### FLAG HANDLING ###
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+  helptext
+  exit 0
+fi
+
+if [ $# -gt 1 ]; then
+  echo "Welcome to the Libki Server Database Restorer."
+  echo
+  echo "You can only use one argument."
+  echo
+  echo
+  exit 1
+fi
+
+# Some simple file checks
+if [ ! -f "$1" ]; then
+  echo "Welcome to the Libki Server Database Restorer."
+  echo
+  echo "The backup you selected doesn't exist. Please try again. Use --help for instructions."
+  exit 1
+fi
+
+if [[ ! "$1" = *.sql ]]; then
+  echo "Welcome to the Libki Server Database Restorer."
+  echo
+  echo "Your file doesn't seem to be a sql file. Please try again. Use --help for instructions."
+  exit 1
+fi
+
+# Start of program
+echo "Welcome to the Libki Server Database Restorer."
+echo
+echo "This will restore your database to the backup you choose."
+echo "It will therefore also delete your current database."
+echo
+echo "Do you wish to continue?"
+
+select ANSWER in "Yes" "No"; do
+  case "$ANSWER" in
+    Yes )
+      break
+      ;;
+    No )
+      exit 0
+      ;;
+    * )
+      echo
+      echo "You must choose 1 (Yes) or 2 (No)"
+      continue
+  esac
+  break
+done
+
+# Run the temp mysql script
+mysql --defaults-extra-file=/home/libki/mysql_tmp.cnf < /home/libki/mysql_tmp_script.sql
+
+# Enter contents of backup into the db
+mysql --defaults-extra-file=/home/libki/mysql_tmp.cnf libki < "$1"
+
+# Remove temp files
+rm /home/libki/mysql_tmp.cnf
+rm /home/libki/mysql_tmp_script.sql
+
+echo
+echo "Your backup has now been entered into your Libki database."
+echo
+
+exit 0


### PR DESCRIPTION
They're both found in script/utilities.

During install they're copied to /usr/local/bin and given the names libki-backup and libki-restore, making them easier to use.

libki-backup will simply make a backup of the current database. It has a flag for silent, meaning it can be used in automated backups via cron.

libki-restore drops the current database before restoring the backup, making sure everything is an exact copy of the point in time of the backup.

It's not a complete upgrade package, but it's a first step :)