### PR TITLE
Issue #64: Fixes timer bug.

### DIFF
--- a/script/cronjobs/libki_nightly.pl
+++ b/script/cronjobs/libki_nightly.pl
@@ -34,7 +34,11 @@ while ( my $user = $user_rs->next() ) {
 
     my $user_minutes = min( $default_time_allowances->{$instance}, $default_session_time_allowances->{$instance} );
 
-    $user->minutes_allotment( $default_time_allowances->{$instance} );
+    # Removes session minutes from daily allotment
+    my $user_minutes_allotment = $default_time_allowances->{$instance};
+    $user_minutes_allotment -= $user_minutes;
+
+    $user->minutes_allotment( $user_minutes_allotment );
     $user->minutes($user_minutes);
     $user->status('disabled') if ( $user->is_troublemaker eq 'Yes' );
     $user->update();


### PR DESCRIPTION
A line deleting the session time from the allotment escaped somewhere during the major instance update. Now it's back and things are working properly again.