### PR TITLE
Allow time for user per day or session using location

### DIFF
--- a/lib/Libki/SIP.pm
+++ b/lib/Libki/SIP.pm
@@ -18,6 +18,7 @@ sub authenticate_via_sip {
 
     my $instance = $c->instance;
     my $config = $c->instance_config;
+    my $client_location = $c->request->params->{'location'};
 
     my $log = $c->log();
 
@@ -207,14 +208,16 @@ sub authenticate_via_sip {
     }
     else {          ## User authenticated and does not exits in Libki
         my $minutes =
-          $c->model('DB::Setting')->find({ instance => $instance, name => 'DefaultTimeAllowance' })->value;
-
+          ($c->model('DB::Setting')->find({ instance => $instance, name => "DefaultTimeAllowance$client_location" })) ? $c->model('DB::Setting')->find({ instance => $instance, name => "DefaultTimeAllowance$client_location" })->value : $c->model('DB::Setting')->find({ instance => $instance, name => "DefaultTimeAllowance" })->value;
+       my $minutes_session =
+             ($c->model('DB::Setting')->find({ instance => $instance, name => "DefaultSessionTimeAllowance$client_location" })) ? $c->model('DB::Setting')->find({ instance => $instance, name   => "DefaultSessionTimeAllowance$client_location" })->value : $c->model('DB::Setting')->find({ instance =>$instance, name => "DefaultSessionTimeAllowance" })->value;
         $user = $c->model('DB::User')->create(
             {
                 instance          => $instance,
                 username          => $username,
                 password          => $password,
                 minutes_allotment => $minutes,
+                minutes           => $minutes_session,
                 status            => 'enabled',
                 birthdate         => $birthdate,
             }

--- a/lib/Libki/Schema/DB/Result/User.pm
+++ b/lib/Libki/Schema/DB/Result/User.pm
@@ -358,19 +358,14 @@ sub insert {
     my $schema = $self->result_source->schema;
 
     my $is_guest = $self->is_guest || 'No';
+    my $minute_allotment = $self->minutes_allotment;
+    my $minutes_session = $self->minutes;
+    $self->minutes(0);
+    my $default_time_allowance_setting = $schema->resultset('Setting')->find({ instance => $self->instance, name => "DefaultGuestTimeAllowance" }) if $is_guest eq 'Yes';
+    my $default_time_allowance = $default_time_allowance_setting ? $default_time_allowance_setting->value : $minute_allotment;
 
-    my $default_time_allowance_setting_name = $is_guest eq 'Yes' ? 'DefaultGuestTimeAllowance' : 'DefaultTimeAllowance';
-    my $default_session_time_allowance_setting_name = $is_guest eq 'Yes' ? 'DefaultGuestSessionTimeAllowance' : 'DefaultSessionTimeAllowance';
-
-    my $default_time_allowance_setting =
-      $schema->resultset('Setting')->find({ instance => $self->instance, name => $default_time_allowance_setting_name });
-    my $default_time_allowance = $default_time_allowance_setting ? $default_time_allowance_setting->value : 0;
-
-    my $default_session_time_allowance_setting =
-      $schema->resultset('Setting')->find({ instance => $self->instance, name => $default_session_time_allowance_setting_name });
-    my $default_session_time_allowance = $default_session_time_allowance_setting ? $default_session_time_allowance_setting->value : 0;
-
-    $self->minutes(0) unless $self->minutes();
+    my $default_session_time_allowance_setting = $schema->resultset('Setting')->find({ instance => $self->instance, name => "DefaultGuestSessionTimeAllowance" }) if $is_guest eq 'Yes';
+    my $default_session_time_allowance = $default_session_time_allowance_setting ? $default_session_time_allowance_setting->value : $minutes_session;
 
     while ($self->minutes() < $default_session_time_allowance
         && $self->minutes_allotment() > 0 )

--- a/root/dynamic/templates/administration/settings/index.tt
+++ b/root/dynamic/templates/administration/settings/index.tt
@@ -37,7 +37,17 @@
                                 </div>
                                 <small class="form-text text-muted">[% c.loc("Amount of time a user is given daily.") %]</small>
                             </div>
-
+                           [% FOREACH t IN timeallowanceperlocation %]
+                               <div class="form-group">
+                                   <label for="[% t.name %]">[% c.loc("Default time allowance per day for ") %][% t.location %]</label>
+                                   <div class="input-group">
+                                       <input type="text" class="form-control" id="[% t.name %]" name="[% t.name %]" value="[% t.time %]">
+                                       <div class="input-group-append">
+                                           <span class="input-group-text">[% c.loc("Minutes") %]</span>
+                                       </div>
+                                    </div>
+                                <small class="form-text text-muted">[% c.loc("Amount of time a user is given daily.") %]</small>
+                           [% END %]
                             <div class="form-group">
                                 <label for="DefaultSessionTimeAllowance">[% c.loc("Default time allowance per session") %]</label>
                                 <div class="input-group">
@@ -48,7 +58,18 @@
                                 </div>
                                 <small class="form-text text-muted">[% c.loc("Amount of time a user is given per session.") %]</small>
                             </div>
-
+                            [% FOREACH t IN timesessionallowanceperlocation %]
+                                <div class="form-group">
+                                    <label for="[% t.name %]">[% c.loc("Default time allowance per session for ") %][% t.location %]</label>
+                                    <div class="input-group">
+                                        <input type="text" class="form-control" id="[% t.name %]" name="[% t.name %]" value="[% t.time %]">
+                                        <div class="input-group-append">
+                                            <span class="input-group-text">[% c.loc("Minutes") %]</span>
+                                        </div>
+                                    </div>
+                                    <small class="form-text text-muted">[% c.loc("Amount of time a user is given per session.") %]</small>
+                                </div>
+                            [% END %]
                             <div class="form-group">
                                 <label for="DefaultGuestTimeAllowance">[% c.loc("Default guest time allowance per day") %]</label>
                                 <div class="input-group">


### PR DESCRIPTION
The need is:
Allow libraries to allocate time to their users by using the location of each client.
Example: A library divides its workstations into two categories, Adult and Young, it allocates 60 minutes for young people and 120 minutes for adults. Now it's not possible, because we can allocate all users the same daily and session time, but with this feature, we can allocate via the administration console a time for each location.
This feature is ready.
Best regards.
Bouzid.