### PR TITLE
Issue #92: Delete sessions without using delete_expired_sessions

### DIFF
--- a/script/cronjobs/libki_nightly.pl
+++ b/script/cronjobs/libki_nightly.pl
@@ -109,7 +109,8 @@ foreach my $prd (@print_retention_days) {
 
 ## Clear out expired sessions
 ## TODO: Should we delete sessions with no expiration periodically?
-$c->delete_expired_sessions();
+
+$c->model('DB::LoginSession')->delete();
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Possible downside: this deletes _all_ sessions. I've tested it and clients aren't logged out, so I don't see any use in storing currently active sessions.