### PR TITLE
Changed log level.

### DIFF
--- a/log4perl.conf.example
+++ b/log4perl.conf.example
@@ -1,4 +1,4 @@
-log4perl.rootLogger			= DEBUG, LOGFILE, SCREEN
+log4perl.rootLogger			= INFO, LOGFILE, SCREEN
 
 log4perl.appender.LOGFILE		= Log::Log4perl::Appender::File
 log4perl.appender.LOGFILE.filename	= /var/log/libki/libki.log


### PR DESCRIPTION
The log level was set to `DEBUG`. I noticed my log file had grown to about 3GB, due to every client registration being logged, which seems... not that useful in a live environment. So I changed it to `INFO`.

@kylemhall I think you should have final say on this - is there a good reason to it being set to debug as default that I'm missing?