### PR TITLE
Db update: non-ascii characters now work properly. (fixes #107)

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -62,7 +62,6 @@ requires 'Server::Starter';
 requires 'Socket';
 requires 'Storable';
 requires 'String::Random';
-requires 'Template::Plugin::UTF8Decode';
 requires 'Term::Prompt';
 requires 'Term::Size::Any';
 requires 'Test::Pod';

--- a/installer/versions/2.05.00.00/01-convert-charset-to-utf8mb4.sql
+++ b/installer/versions/2.05.00.00/01-convert-charset-to-utf8mb4.sql
@@ -2,20 +2,19 @@
 
 ALTER DATABASE libki CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-ALTER TABLE client_age_limits CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE clients CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE closing_hours CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE jobs CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE locations CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE login_sessions CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE messages CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE print_files CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE print_jobs CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE reservations CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE roles CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE sessions CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE settings CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE statistics CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE user_roles CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-ALTER TABLE users CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
+ALTER TABLE client_age_limits CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE clients CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE closing_hours CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE jobs CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE locations CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE login_sessions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE messages CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE print_files CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE print_jobs CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE reservations CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE roles CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE sessions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE settings CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE statistics CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE user_roles CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE users CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/installer/versions/2.05.00.00/01-convert-charset-to-utf8mb4.sql
+++ b/installer/versions/2.05.00.00/01-convert-charset-to-utf8mb4.sql
@@ -1,0 +1,21 @@
+-- Convert everything to utf8mb4
+
+ALTER DATABASE libki CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+ALTER TABLE client_age_limits CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE clients CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE closing_hours CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE jobs CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE locations CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE login_sessions CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE messages CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE print_files CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE print_jobs CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE reservations CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE roles CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE sessions CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE settings CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE statistics CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE user_roles CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+ALTER TABLE users CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+

--- a/lib/Catalyst/Plugin/LibkiSetting.pm
+++ b/lib/Catalyst/Plugin/LibkiSetting.pm
@@ -3,6 +3,8 @@ package Catalyst::Plugin::LibkiSetting;
 use Modern::Perl;
 use List::Util qw(any);
 
+use Encode qw/decode encode/;
+
 our $VERSION = 1;
 
 =head2 setting
@@ -64,11 +66,13 @@ sub instance_config {
 
     unless ( $config->{SIP} ) {
         my $yaml = $c->setting('SIPConfiguration');
+        $yaml = encode('UTF-8',$yaml);
         $config->{SIP} = YAML::XS::Load($yaml) if $yaml;
     }
 
     unless ( $config->{LDAP} ) {
         my $yaml = $c->setting('LDAPConfiguration');
+        $yaml = encode('UTF-8',$yaml);
         $config->{LDAP} = YAML::XS::Load($yaml) if $yaml;
     }
 
@@ -107,6 +111,8 @@ sub user_categories {
     my ( $c ) = @_;
 
     my $yaml = $c->setting('UserCategories');
+
+    $yaml = encode('UTF-8',$yaml);
 
     my $categories = YAML::XS::Load($yaml) if $yaml;
 
@@ -155,6 +161,7 @@ sub get_rules {
     return $c->stash->{AdvancedRules} if defined $c->stash->{AdvancedRules};
 
     my $yaml = $c->setting( { instance => $instance, name => 'AdvancedRules' } );
+    $yaml = encode('UTF-8',$yaml);
 
     my $data = YAML::XS::Load($yaml) if $yaml;
 
@@ -219,6 +226,8 @@ sub get_printer_configuration {
     $params->{name} = 'PrinterConfiguration';
 
     my $yaml   = $c->setting($params);
+    $yaml = encode('UTF-8',$yaml);
+
     my $config = YAML::XS::Load($yaml);
     return $config;
 }

--- a/lib/Libki/Controller/API/Public.pm
+++ b/lib/Libki/Controller/API/Public.pm
@@ -3,8 +3,6 @@ package Libki::Controller::API::Public;
 use Moose;
 use namespace::autoclean;
 
-use Encode qw(decode encode);
-
 BEGIN { extends 'Catalyst::Controller'; }
 
 =head1 NAME
@@ -54,7 +52,7 @@ sub client : Local : Args(1) {
 
                 $c->stash(
                     username   => $user->username(),
-                    clientname => decode('UTF-8',$client->name()),
+                    clientname => $client->name(),
                     instance   => $instance,
                 );
                 $c->log()->debug( "API::Public::client returning ( username => " . $user->username() . ", clientname => " . $client->name() . " )" );

--- a/lib/Libki/Controller/API/Public/Datatables.pm
+++ b/lib/Libki/Controller/API/Public/Datatables.pm
@@ -2,8 +2,6 @@ package Libki::Controller::API::Public::Datatables;
 use Moose;
 use namespace::autoclean;
 
-use Encode qw(decode);
-
 BEGIN { extends 'Catalyst::Controller'; }
 
 =head1 NAME
@@ -80,12 +78,11 @@ sub clients : Local Args(0) {
 
     my @results;
     foreach my $c (@clients) {
-	    my $enc = 'utf-8';
 
         my $r;
         $r->{'DT_RowId'} = $c->id;
-        $r->{'0'} = decode($enc,decode($enc,$c->name));
-        $r->{'1'} = decode($enc,decode($enc,$c->location));
+        $r->{'0'} = $c->name;
+        $r->{'1'} = $c->location;
         $r->{'2'} = defined( $c->session ) ? $c->session->status : undef;
         $r->{'3'} = defined( $c->session ) ? $c->session->minutes : undef;
         $r->{'4'} = defined( $c->reservation ) ? $c->reservation->user->username : undef;

--- a/lib/Libki/Controller/Administration.pm
+++ b/lib/Libki/Controller/Administration.pm
@@ -2,8 +2,6 @@ package Libki::Controller::Administration;
 use Moose;
 use namespace::autoclean;
 
-use Encode qw(decode encode);
-
 BEGIN { extends 'Catalyst::Controller'; }
 
 =head1 NAME
@@ -32,7 +30,7 @@ sub index : Path : Args(0) {
             instance => $instance,
         },
         {
-            columns  => decode('UTF-8',[qw/location/]),
+            columns  => [qw/location/],
             distinct => 1
         }
     )->get_column('location')->all();

--- a/lib/Libki/Controller/Administration/API/DataTables.pm
+++ b/lib/Libki/Controller/Administration/API/DataTables.pm
@@ -3,8 +3,6 @@ package Libki::Controller::Administration::API::DataTables;
 use Moose;
 use namespace::autoclean;
 
-use Encode qw(decode encode);
-
 BEGIN { extends 'Catalyst::Controller'; }
 
 =head1 NAME
@@ -88,22 +86,20 @@ sub users : Local Args(0) {
     my @results;
     foreach my $u (@users) {
 
-        my $enc = 'UTF-8';
-
         my $r;
         $r->{'DT_RowId'} = $u->id;
-        $r->{'0'}        = decode( $enc, $u->username);
-        $r->{'1'}        = decode( $enc, $u->lastname);
-        $r->{'2'}        = decode( $enc, $u->firstname);
-        $r->{'3'}        = decode( $enc, $u->category);
+        $r->{'0'}        = $u->username;
+        $r->{'1'}        = $u->lastname;
+        $r->{'2'}        = $u->firstname;
+        $r->{'3'}        = $u->category;
         $r->{'4'}        = $u->minutes_allotment;
         $r->{'5'}        = $u->session ? $u->session->minutes : undef;
         $r->{'6'}        = $u->status;
-        $r->{'7'}        = decode( $enc, $u->notes);
+        $r->{'7'}        = $u->notes;
         $r->{'8'}        = $u->is_troublemaker;
         $r->{'9'}        =
           defined( $u->session )
-          ? decode($enc,decode( $enc, $u->session->client->name)) : undef;
+          ? $u->session->client->name : undef;
         $r->{'10'}        = defined( $u->session ) ? $u->session->status : undef;
 
         push( @results, $r );
@@ -193,23 +189,21 @@ sub clients : Local Args(0) {
     my @results;
     foreach my $c (@clients) {
 
-        my $enc = 'UTF-8';
-
         my $r;
         $r->{'DT_RowId'} = $c->id;
-        $r->{'0'} = decode( $enc, decode( $enc, $c->name ) );
-        $r->{'1'} = decode( $enc, decode( $enc, $c->location ) );
+        $r->{'0'} = $c->name;
+        $r->{'1'} = $c->location;
         $r->{'2'} = defined( $c->session ) ? $c->session->status : undef;
-        $r->{'3'} = defined( $c->session ) ? decode( $enc, $c->session->user->username ) : undef;
-        $r->{'4'} = defined( $c->session ) ? decode($enc,$c->session->user->lastname) : undef;
-        $r->{'5'} = defined( $c->session ) ? decode($enc,$c->session->user->firstname) : undef;
-        $r->{'6'} = defined( $c->session ) ? decode($enc,$c->session->user->category) : undef;
+        $r->{'3'} = defined( $c->session ) ? $c->session->user->username : undef;
+        $r->{'4'} = defined( $c->session ) ? $c->session->user->lastname : undef;
+        $r->{'5'} = defined( $c->session ) ? $c->session->user->firstname : undef;
+        $r->{'6'} = defined( $c->session ) ? $c->session->user->category : undef;
         $r->{'7'} = defined( $c->session ) ? $c->session->user->minutes_allotment : undef;
         $r->{'8'} = defined( $c->session ) ? $c->session->minutes : undef;
         $r->{'9'} = defined( $c->session ) ? $c->session->user->status  : undef;
-        $r->{'10'} = defined( $c->session ) ? decode( $enc, $c->session->user->notes ) : undef;
+        $r->{'10'} = defined( $c->session ) ? $c->session->user->notes : undef;
         $r->{'11'} = defined( $c->session ) ? $c->session->user->is_troublemaker : undef;
-        $r->{'12'} = defined( $c->reservation ) ? decode( $enc, $c->reservation->user->username ) : undef;
+        $r->{'12'} = defined( $c->reservation ) ? $c->reservation->user->username : undef;
         push( @results, $r );
     }
 
@@ -283,12 +277,10 @@ sub statistics : Local Args(0) {
     my @results;
     foreach my $s (@stats) {
 
-        my $enc = 'UTF-8';
-
         my $r;
         $r->{'DT_RowId'} = $s->id;
-        $r->{'0'}        = decode( $enc, $s->username );
-        $r->{'1'}        = decode( $enc, decode( $enc, $s->client_name ) );
+        $r->{'0'}        = $s->username;
+        $r->{'1'}        = $s->client_name;
         $r->{'2'}        = $s->action;
         $r->{'3'}        = $s->created_on->strftime('%m/%d/%Y %I:%M %p');
 
@@ -382,8 +374,6 @@ sub prints : Local Args(0) {
 
     my @results;
     foreach my $p (@prints) {
-
-        my $enc = 'UTF-8';
 
         my $r;
         $r->{'DT_RowId'} = $p->id;

--- a/lib/Libki/Controller/Administration/API/User.pm
+++ b/lib/Libki/Controller/Administration/API/User.pm
@@ -5,8 +5,6 @@ use String::Random qw(random_string);
 
 use namespace::autoclean;
 
-use Encode qw(decode encode);
-
 BEGIN { extends 'Catalyst::Controller'; }
 
 =head1 NAME
@@ -31,8 +29,6 @@ sub get : Local : Args(1) {
 
     my $user = $c->model('DB::User')->find({ instance => $instance, id => $id });
 
-    my $enc = 'UTF-8';
-
     my $roles = $user->roles;
     my @roles;
     while ( my $role = $roles->next() ) {
@@ -42,13 +38,13 @@ sub get : Local : Args(1) {
     $c->stash(
         {
             id              => $user->id,
-            username        => decode( $enc, $user->username ),
+            username        => $user->username,
             firstname       => $user->firstname,
             lastname        => $user->lastname,
             category        => $user->category,
             minutes         => $user->minutes_allotment,
             status          => $user->status,
-            notes           => decode( $enc, $user->notes ),
+            notes           => $user->notes,
             is_troublemaker => $user->is_troublemaker,
             roles           => \@roles,
         }

--- a/lib/Libki/Controller/Administration/History.pm
+++ b/lib/Libki/Controller/Administration/History.pm
@@ -78,8 +78,6 @@ sub statistics : Local : Args(0) {
         }
     );
     
-    my $enc = 'UTF-8';
-
     my $results;
     my $columns;
 

--- a/lib/Libki/Controller/Administration/Hours.pm
+++ b/lib/Libki/Controller/Administration/Hours.pm
@@ -7,8 +7,6 @@ BEGIN { extends 'Catalyst::Controller'; }
 our @days_of_week =
   qw( Monday Tuesday Wednesday Thursday Friday Saturday Sunday );
 
-=encoding utf8
-
 =head1 NAME
 
 Libki::Controller::Administration::Hours - Catalyst Controller

--- a/lib/Libki/I18N/sv.po
+++ b/lib/Libki/I18N/sv.po
@@ -800,8 +800,7 @@ msgstr "Prefix för gästpass"
 #: root/dynamic/templates/administration/settings/index.tt:452
 msgid "Prefix for guest passes, defaults to 'guest' if none is specified."
 msgstr ""
-"Prefix för gästpass. Om det inte ändras kommer värdet bli \"guest\". Notera "
-"att ÅÄÖ inte fungerar här ännu."
+"Prefix för gästpass. Om det inte ändras kommer värdet bli \"guest\"."
 
 #: root/dynamic/templates/administration/index.tt:216
 msgid "Print"
@@ -845,7 +844,7 @@ msgstr "Uppdatera"
 
 #: root/dynamic/templates/administration/settings/index.tt:306
 msgid "Renew the time allotment when it reaches zero"
-msgstr "Förnya tidsmöngden när den når noll"
+msgstr "Förnya tidsmängden när den når noll"
 
 #: root/dynamic/templates/administration/index.tt:1139
 #: root/dynamic/templates/public/index.tt:378

--- a/lib/Libki/Schema/DB.pm
+++ b/lib/Libki/Schema/DB.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/Client.pm
+++ b/lib/Libki/Schema/DB/Result/Client.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::Client;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/ClientAgeLimit.pm
+++ b/lib/Libki/Schema/DB/Result/ClientAgeLimit.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::ClientAgeLimit;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/ClosingHour.pm
+++ b/lib/Libki/Schema/DB/Result/ClosingHour.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::ClosingHour;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/Job.pm
+++ b/lib/Libki/Schema/DB/Result/Job.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::Job;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/Location.pm
+++ b/lib/Libki/Schema/DB/Result/Location.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::Location;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/LoginSession.pm
+++ b/lib/Libki/Schema/DB/Result/LoginSession.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::LoginSession;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/Message.pm
+++ b/lib/Libki/Schema/DB/Result/Message.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::Message;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/PrintFile.pm
+++ b/lib/Libki/Schema/DB/Result/PrintFile.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::PrintFile;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/PrintJob.pm
+++ b/lib/Libki/Schema/DB/Result/PrintJob.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::PrintJob;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/Reservation.pm
+++ b/lib/Libki/Schema/DB/Result/Reservation.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::Reservation;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/Role.pm
+++ b/lib/Libki/Schema/DB/Result/Role.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::Role;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/Session.pm
+++ b/lib/Libki/Schema/DB/Result/Session.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::Session;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/Setting.pm
+++ b/lib/Libki/Schema/DB/Result/Setting.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::Setting;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/Statistic.pm
+++ b/lib/Libki/Schema/DB/Result/Statistic.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::Statistic;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/User.pm
+++ b/lib/Libki/Schema/DB/Result/User.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::User;
 
 # Created by DBIx::Class::Schema::Loader

--- a/lib/Libki/Schema/DB/Result/UserRole.pm
+++ b/lib/Libki/Schema/DB/Result/UserRole.pm
@@ -1,4 +1,3 @@
-use utf8;
 package Libki::Schema::DB::Result::UserRole;
 
 # Created by DBIx::Class::Schema::Loader

--- a/libki_local.conf.example
+++ b/libki_local.conf.example
@@ -5,6 +5,7 @@
         password "PASSWORD"
         auto_savepoint 1
         quote_names 1
+	mysql_enable_utf8mb4 1
     </connect_info>
 </Model::DB>
 

--- a/root/dynamic/templates/administration/history/statistics.tt
+++ b/root/dynamic/templates/administration/history/statistics.tt
@@ -1,7 +1,5 @@
 [% USE LibkiDate %]
 
-[% USE UTF8Decode %]
-
 [% meta.title = c.loc("Administration / History / Statistics") %]
 [% SET active_class = 'administration__history__statistics' %]
 
@@ -49,7 +47,7 @@
                     [% IF b == 'XXX__UNDEFINED__' %]
                         <i>[% c.loc("No location set") %]</i>
                     [% ELSE %]
-                        [% b |utf8_decode | utf8_decode %]
+                        [% b %]
                     [% END %]
                 </th>
             [% END %]

--- a/root/dynamic/templates/administration/index.tt
+++ b/root/dynamic/templates/administration/index.tt
@@ -1,6 +1,5 @@
 [% meta.title = c.loc("Administration") %]
 [% SET active_class = 'administration__index' %]
-[% USE UTF8Decode %]
 
 <ul class="nav nav-tabs" id="primaryTabs" role="tablist">
   <li class="nav-item">
@@ -83,7 +82,7 @@
           </li>
           [% FOREACH location IN locations %]
               <li class="nav-item">
-                  <a class="nav-link" data-toggle="pill" href="#" onclick="ClientTableUpdateLocationFilter(`[% location %]`);">[% location | utf8_decode | utf8_decode %]</a>
+                  <a class="nav-link" data-toggle="pill" href="#" onclick="ClientTableUpdateLocationFilter(`[% location %]`);">[% location %]</a>
               </li>
           [% END %]
         </ul>
@@ -157,7 +156,7 @@
           </li>
           [% FOREACH location IN locations %]
               <li class="nav-item">
-                  <a class="nav-link" data-toggle="pill" href="#" onclick="PrintTableUpdateLocationFilter(`[% location %]`);">[% location | utf8_decode | utf8_decode %]</a>
+                  <a class="nav-link" data-toggle="pill" href="#" onclick="PrintTableUpdateLocationFilter(`[% location %]`);">[% location %]</a>
               </li>
           [% END %]
         </ul>

--- a/root/dynamic/templates/public/index.tt
+++ b/root/dynamic/templates/public/index.tt
@@ -1,5 +1,4 @@
 [% SET active_class = "public__index" %]
-[% USE UTF8Decode %]
 
 <nav class="navbar navbar-expand-lg navbar-light bg-none">
     <ul class="nav nav-pills" id="primary-tabs">
@@ -11,7 +10,7 @@
       </li>
       [% FOREACH location IN locations %]
           <li class="nav-item">
-              <a class="nav-link" data-toggle="pill" href="#" onclick="ClientTableUpdateLocationFilter(`[% location %]`);">[% location | utf8_decode | utf8_decode %]</a>
+              <a class="nav-link" data-toggle="pill" href="#" onclick="ClientTableUpdateLocationFilter(`[% location %]`);">[% location %]</a>
           </li>
       [% END %]
     </ul>


### PR DESCRIPTION
Short version:
* Everything works as expected. Non-ascii characters are stored in the database correctly and are displayed correctly.
* We never have to bother about defining character sets when creating another table.

Observe! No one should never, ever upgrade to this from an old database if the old database contains non-ascii characters. It won't break the entire installation, but it will break things for those users having non-ascii characters in their usernames.

Long version: I never want to read another line about character encoding again.

* what was really needed was `mysql_enable_utf8mb4 1` in the connect info. That made mysql understand that we sent one four byte character (utf8) rather than two two byte characters (ascii).
* We don't need to use the `use utf8` pragma. That only enables utf8 capability within the file, say if we want to use the variable $öxölklöfför. And we don't do that. So I got rid of all of those.
* I converted the entire database to utf8mb4, because fun thing - mysql's utf8 isn't utf8. Utf8 uses four bytes, and mysql's utf8 uses three. This works fine with some non-ascii characters, but not with others.
* All decode() are gone == a lot of code is easier to read.
* I found a bug in the categories. Apparently YAML::XS really doesn't like utf8, so strings loaded with it needs to be encoded to utf8 despite already being in utf8... I don't really get it either, but now it works.
* Batch created guest passes can now contain non-ascii characters as well, since this too was broken before.