### PR TITLE
Hiding unused fields.

### DIFF
--- a/lib/Libki/Controller/Administration.pm
+++ b/lib/Libki/Controller/Administration.pm
@@ -39,6 +39,8 @@ sub index : Path : Args(0) {
         DefaultTimeAllowance   => $c->setting('DefaultTimeAllowance'),
         CustomJsAdministration => $c->setting('CustomJsAdministration'),
         PrinterConfiguration   => $c->setting('PrinterConfiguration'),
+        ShowFirstLastNames     => $c->setting('ShowFirstLastNames'),
+        UserCategories	       => $c->setting('UserCategories'),
         locations              => \@locations,
     );
 }

--- a/lib/Libki/Controller/Administration/Settings.pm
+++ b/lib/Libki/Controller/Administration/Settings.pm
@@ -81,6 +81,15 @@ sub update :Local :Args(0) {
         }
     );
 
+    # And so is ShowFirstLastNames
+    $c->model('DB::Setting')->update_or_create(
+        {
+            instance => $instance,
+            name     => 'ShowFirstLastNames',
+            value    => ( $c->request->params->{ShowFirstLastNames} // 0 ) eq 'on' ? 1 : 0,
+        }
+    );
+
     $c->response->redirect( $c->uri_for( $self->action_for('index') ) );
 }
 

--- a/lib/Libki/I18N/messages.pot
+++ b/lib/Libki/I18N/messages.pot
@@ -15,8 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: root/dynamic/templates/administration/hours/index.tt:31 root/dynamic/templates/administration/hours/index.tt:57
-msgid "$d"
+#: root/dynamic/includes/language_menu.tt:0
+msgid "('lang.' _ lang)"
 msgstr ""
 
 #: root/dynamic/templates/administration/history/index.tt:8
@@ -27,7 +27,7 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:516
+#: root/dynamic/templates/administration/index.tt:526
 msgid "Add a + or - sign to increment or decrement the existing amount of time."
 msgstr ""
 
@@ -35,15 +35,15 @@ msgstr ""
 msgid "Add closing hours for specific dates"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:491
+#: root/dynamic/templates/administration/settings/index.tt:509
 msgid "Add custom CSS for batch guest passes here."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:554
+#: root/dynamic/templates/administration/settings/index.tt:572
 msgid "Add custom JavaScript for the administration interface here."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:562
+#: root/dynamic/templates/administration/settings/index.tt:580
 msgid "Add custom JavaScript for the public web interface here."
 msgstr ""
 
@@ -63,7 +63,7 @@ msgstr ""
 msgid "Administration / History"
 msgstr ""
 
-#: root/dynamic/templates/administration/history/statistics.tt:5
+#: root/dynamic/templates/administration/history/statistics.tt:3
 msgid "Administration / History / Statistics"
 msgstr ""
 
@@ -71,19 +71,19 @@ msgstr ""
 msgid "Administration / Settings"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:550
+#: root/dynamic/templates/administration/settings/index.tt:568
 msgid "Administration interface JavaScript"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:480
+#: root/dynamic/templates/administration/index.tt:490
 msgid "Administrator"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:572
+#: root/dynamic/templates/administration/settings/index.tt:590
 msgid "Advanced rules"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:22 root/dynamic/templates/administration/settings/index.tt:569
+#: root/dynamic/templates/administration/settings/index.tt:22 root/dynamic/templates/administration/settings/index.tt:587
 msgid "Advanced settings"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 msgid "Alert:"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:156 root/dynamic/templates/administration/index.tt:82 root/dynamic/templates/public/index.tt:10
+#: root/dynamic/templates/administration/index.tt:163 root/dynamic/templates/administration/index.tt:85 root/dynamic/templates/public/index.tt:9
 msgid "All"
 msgstr ""
 
@@ -123,15 +123,15 @@ msgstr ""
 msgid "Any client is reserved"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1136
+#: root/dynamic/templates/administration/index.tt:1150
 msgid "Are you sure you want to cancel the reservation for this client?"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1106
+#: root/dynamic/templates/administration/index.tt:1120
 msgid "Are you sure you want to delete this user?"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1120
+#: root/dynamic/templates/administration/index.tt:1134
 msgid "Are you sure you want to log this user out?"
 msgstr ""
 
@@ -139,31 +139,31 @@ msgstr ""
 msgid "Automatic time extension"
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:141
+#: root/dynamic/templates/public/index.tt:140
 msgid "Available"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:404
+#: root/dynamic/templates/administration/settings/index.tt:422
 msgid "Bottom banner"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:248 root/dynamic/templates/administration/index.tt:325 root/dynamic/templates/administration/index.tt:493 root/dynamic/templates/administration/index.tt:524 root/dynamic/templates/administration/index.tt:555 root/dynamic/templates/administration/index.tt:587 root/dynamic/templates/public/index.tt:110 root/dynamic/templates/public/index.tt:75
+#: root/dynamic/templates/administration/index.tt:255 root/dynamic/templates/administration/index.tt:335 root/dynamic/templates/administration/index.tt:503 root/dynamic/templates/administration/index.tt:534 root/dynamic/templates/administration/index.tt:565 root/dynamic/templates/administration/index.tt:601 root/dynamic/templates/public/index.tt:109 root/dynamic/templates/public/index.tt:74
 msgid "Cancel"
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:111 root/dynamic/templates/public/index.tt:38 root/dynamic/templates/public/index.tt:91
+#: root/dynamic/templates/public/index.tt:110 root/dynamic/templates/public/index.tt:37 root/dynamic/templates/public/index.tt:90
 msgid "Cancel reservation"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:130 root/dynamic/templates/administration/index.tt:291 root/dynamic/templates/administration/index.tt:448 root/dynamic/templates/administration/index.tt:52
+#: root/dynamic/templates/administration/index.tt:136 root/dynamic/templates/administration/index.tt:300 root/dynamic/templates/administration/index.tt:458 root/dynamic/templates/administration/index.tt:54
 msgid "Category"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:566 root/dynamic/templates/administration/index.tt:588
+#: root/dynamic/templates/administration/index.tt:580 root/dynamic/templates/administration/index.tt:602
 msgid "Change password"
 msgstr ""
 
-#: root/dynamic/templates/administration/history/index.tt:7 root/dynamic/templates/administration/index.tt:203 root/dynamic/templates/administration/index.tt:58 root/dynamic/templates/public/index.tt:22
+#: root/dynamic/templates/administration/history/index.tt:7 root/dynamic/templates/administration/index.tt:210 root/dynamic/templates/administration/index.tt:61 root/dynamic/templates/public/index.tt:21
 msgid "Client"
 msgstr ""
 
@@ -183,7 +183,7 @@ msgstr ""
 msgid "Client inactivity warning"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:364
+#: root/dynamic/templates/administration/settings/index.tt:382
 msgid "Client login banner settings"
 msgstr ""
 
@@ -203,11 +203,11 @@ msgstr ""
 msgid "Client reservations"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:59
+#: root/dynamic/templates/administration/index.tt:62
 msgid "Client status"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:10
+#: root/dynamic/templates/administration/index.tt:9
 msgid "Clients"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Closing hours"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:304 root/dynamic/templates/administration/index.tt:580 root/dynamic/templates/administration/index.tt:581
+#: root/dynamic/templates/administration/index.tt:314 root/dynamic/templates/administration/index.tt:594 root/dynamic/templates/administration/index.tt:595
 msgid "Confirm password"
 msgstr ""
 
@@ -227,27 +227,27 @@ msgstr ""
 msgid "Control whether a user's time extension uses up minutes from the user's daily allotment, or if the minutes are \"free\"."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:326
+#: root/dynamic/templates/administration/index.tt:336
 msgid "Create user"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:205
+#: root/dynamic/templates/administration/index.tt:212
 msgid "Created"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:14 root/dynamic/templates/administration/settings/index.tt:547
+#: root/dynamic/templates/administration/settings/index.tt:14 root/dynamic/templates/administration/settings/index.tt:565
 msgid "Custom JavaScript"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:131 root/dynamic/templates/administration/index.tt:53
+#: root/dynamic/templates/administration/index.tt:138 root/dynamic/templates/administration/index.tt:56
 msgid "Daily minutes"
 msgstr ""
 
-#: root/dynamic/templates/administration/history/statistics.tt:39
+#: root/dynamic/templates/administration/history/statistics.tt:37
 msgid "Daily usage"
 msgstr ""
 
-#: root/dynamic/templates/administration/history/statistics.tt:41
+#: root/dynamic/templates/administration/history/statistics.tt:39
 msgid "Daily usage, count of daily logins by location"
 msgstr ""
 
@@ -255,7 +255,7 @@ msgstr ""
 msgid "Data retention"
 msgstr ""
 
-#: root/dynamic/templates/administration/history/statistics.tt:44
+#: root/dynamic/templates/administration/history/statistics.tt:42
 msgid "Date"
 msgstr ""
 
@@ -283,19 +283,19 @@ msgstr ""
 msgid "Default time allowance per session"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:526
+#: root/dynamic/templates/administration/settings/index.tt:544
 msgid "Define LDAP configuration in YAML format. This setting may be overridden by a LDAP block in the Libki conf file."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:518
+#: root/dynamic/templates/administration/settings/index.tt:536
 msgid "Define SIP configuration in YAML format. This setting may be overridden by a SIP block in the Libki conf file."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:540
+#: root/dynamic/templates/administration/settings/index.tt:558
 msgid "Define printer configuration in YAML format."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:70
+#: root/dynamic/templates/administration/index.tt:73
 msgid "Delete"
 msgstr ""
 
@@ -303,16 +303,20 @@ msgstr ""
 msgid "Delete selected"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:418
+#: root/dynamic/templates/administration/index.tt:428
 msgid "Details"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:467
+#: root/dynamic/templates/administration/index.tt:477
 msgid "Disabled"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:360 root/dynamic/templates/administration/index.tt:396
+#: root/dynamic/templates/administration/index.tt:370 root/dynamic/templates/administration/index.tt:406
 msgid "Dismiss"
+msgstr ""
+
+#: root/dynamic/templates/administration/settings/index.tt:361
+msgid "Display first and last names"
 msgstr ""
 
 #: root/dynamic/templates/administration/settings/index.tt:228
@@ -323,28 +327,32 @@ msgstr ""
 msgid "Don't take minutes from daily allotment"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:232
+#: root/dynamic/templates/administration/index.tt:239
 msgid "Download"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:65
+#: root/dynamic/templates/administration/index.tt:68
 msgid "Edit"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:407
+#: root/dynamic/templates/administration/index.tt:417
 msgid "Edit user"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:466
+#: root/dynamic/templates/administration/index.tt:476
 msgid "Enabled"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:506
+#: root/dynamic/templates/administration/settings/index.tt:524
 msgid "Entering a url here will cause a username to become a hyperlink with the user's username at the end. Make sure to add <i>http://</i> or <i>https://</i> at the beginning."
 msgstr ""
 
 #: root/dynamic/includes/wrapper.tt:51
 msgid "Error:"
+msgstr ""
+
+#: root/dynamic/templates/administration/settings/index.tt:350
+msgid "Example:"
 msgstr ""
 
 #: root/dynamic/templates/administration/settings/index.tt:270
@@ -363,11 +371,11 @@ msgstr ""
 msgid "Extension length"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1211
+#: root/dynamic/templates/administration/index.tt:1225
 msgid "Failed to release print job: "
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:201
+#: root/dynamic/templates/administration/index.tt:208
 msgid "File name"
 msgstr ""
 
@@ -379,35 +387,35 @@ msgstr ""
 msgid "First come, first served. A patron walks up to an open client and logs in."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:282 root/dynamic/templates/administration/index.tt:439
+#: root/dynamic/templates/administration/index.tt:290 root/dynamic/templates/administration/index.tt:449
 msgid "First name"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:129 root/dynamic/templates/administration/index.tt:51
+#: root/dynamic/templates/administration/index.tt:133 root/dynamic/templates/administration/index.tt:51
 msgid "Firstname"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:509
+#: root/dynamic/templates/administration/settings/index.tt:527
 msgid "For example, <i>http://catalog.koha.library/cgi-bin/koha/members/member.pl?quicksearch=1&searchmember=</i> will link to the Koha ILS's search function for the given username."
 msgstr ""
 
-#: root/dynamic/templates/administration/history/statistics.tt:13 root/dynamic/templates/administration/history/statistics.tt:16
+#: root/dynamic/templates/administration/history/statistics.tt:11 root/dynamic/templates/administration/history/statistics.tt:14
 msgid "From"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:487
+#: root/dynamic/templates/administration/settings/index.tt:505
 msgid "Guest pass CSS"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:16 root/dynamic/templates/administration/settings/index.tt:445
+#: root/dynamic/templates/administration/settings/index.tt:16 root/dynamic/templates/administration/settings/index.tt:463
 msgid "Guest passes"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:392 root/dynamic/templates/administration/settings/index.tt:429
+#: root/dynamic/templates/administration/settings/index.tt:410 root/dynamic/templates/administration/settings/index.tt:447
 msgid "Height"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:378
+#: root/dynamic/templates/administration/index.tt:388
 msgid "Highest guest account created"
 msgstr ""
 
@@ -427,7 +435,7 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:17 root/dynamic/templates/administration/settings/index.tt:498
+#: root/dynamic/templates/administration/settings/index.tt:17 root/dynamic/templates/administration/settings/index.tt:516
 msgid "ILS integration"
 msgstr ""
 
@@ -435,15 +443,19 @@ msgstr ""
 msgid "If a Libki client has not re-registered itself within this amount of time, it will be removed from the list of active clients."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:579
+#: root/dynamic/templates/administration/settings/index.tt:597
 msgid "If no match is found, the default time allowances will be used."
+msgstr ""
+
+#: root/dynamic/templates/administration/settings/index.tt:362
+msgid "If not checked, the possibility to enter users' first and last name will disappear."
 msgstr ""
 
 #: root/dynamic/templates/administration/settings/index.tt:335
 msgid "If text is added here for terms of service, it will be displayed in click-though dialog on the client before allowing a login."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:139
+#: root/dynamic/templates/public/index.tt:138
 msgid "In use"
 msgstr ""
 
@@ -451,7 +463,7 @@ msgstr ""
 msgid "Inactive user retention"
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:385
+#: root/dynamic/templates/public/index.tt:384
 msgid "Incorrect password."
 msgstr ""
 
@@ -459,11 +471,11 @@ msgstr ""
 msgid "Info:"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:319
+#: root/dynamic/templates/administration/index.tt:329
 msgid "Is not a whole number"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:522
+#: root/dynamic/templates/administration/settings/index.tt:540
 msgid "LDAP configuration"
 msgstr ""
 
@@ -471,15 +483,15 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:285 root/dynamic/templates/administration/index.tt:442
+#: root/dynamic/templates/administration/index.tt:293 root/dynamic/templates/administration/index.tt:452
 msgid "Last name"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:128 root/dynamic/templates/administration/index.tt:50
+#: root/dynamic/templates/administration/index.tt:132 root/dynamic/templates/administration/index.tt:50
 msgid "Lastname"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:317 root/dynamic/templates/administration/index.tt:460
+#: root/dynamic/templates/administration/index.tt:327 root/dynamic/templates/administration/index.tt:470
 msgid "Leave unmodified for default amount of time."
 msgstr ""
 
@@ -499,11 +511,11 @@ msgstr ""
 msgid "Libki Kiosk Management System"
 msgstr ""
 
-#: root/dynamic/templates/administration/history/statistics.tt:33
+#: root/dynamic/templates/administration/history/statistics.tt:31
 msgid "Limit"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:125 root/dynamic/templates/administration/index.tt:153 root/dynamic/templates/administration/index.tt:79 root/dynamic/templates/public/index.tt:23 root/dynamic/templates/public/index.tt:7
+#: root/dynamic/templates/administration/index.tt:128 root/dynamic/templates/administration/index.tt:160 root/dynamic/templates/administration/index.tt:82 root/dynamic/templates/public/index.tt:22 root/dynamic/templates/public/index.tt:6
 msgid "Location"
 msgstr ""
 
@@ -511,7 +523,7 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: root/dynamic/includes/navbar_administration.tt:36 root/dynamic/templates/administration/index.tt:144
+#: root/dynamic/includes/navbar_administration.tt:36 root/dynamic/templates/administration/index.tt:151
 msgid "Log out"
 msgstr ""
 
@@ -519,15 +531,15 @@ msgstr ""
 msgid "Log user out automatically after this many minutes of inactivity."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1123
+#: root/dynamic/templates/administration/index.tt:1137
 msgid "Logged user out."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:535 root/dynamic/templates/administration/index.tt:556 root/dynamic/templates/public/index.tt:34 root/dynamic/templates/public/index.tt:76
+#: root/dynamic/templates/administration/index.tt:545 root/dynamic/templates/administration/index.tt:566 root/dynamic/templates/public/index.tt:33 root/dynamic/templates/public/index.tt:75
 msgid "Make reservation"
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:48
+#: root/dynamic/templates/public/index.tt:47
 msgid "Make reservation for"
 msgstr ""
 
@@ -535,11 +547,11 @@ msgstr ""
 msgid "Manage existing specific dates"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:315 root/dynamic/templates/administration/index.tt:354 root/dynamic/templates/administration/index.tt:388 root/dynamic/templates/administration/index.tt:458 root/dynamic/templates/administration/index.tt:514 root/dynamic/templates/administration/settings/index.tt:176 root/dynamic/templates/administration/settings/index.tt:187 root/dynamic/templates/administration/settings/index.tt:202 root/dynamic/templates/administration/settings/index.tt:219 root/dynamic/templates/administration/settings/index.tt:256 root/dynamic/templates/administration/settings/index.tt:267 root/dynamic/templates/administration/settings/index.tt:37 root/dynamic/templates/administration/settings/index.tt:48 root/dynamic/templates/administration/settings/index.tt:59 root/dynamic/templates/administration/settings/index.tt:70 root/dynamic/templates/public/index.tt:145
+#: root/dynamic/templates/administration/index.tt:325 root/dynamic/templates/administration/index.tt:364 root/dynamic/templates/administration/index.tt:398 root/dynamic/templates/administration/index.tt:468 root/dynamic/templates/administration/index.tt:524 root/dynamic/templates/administration/settings/index.tt:176 root/dynamic/templates/administration/settings/index.tt:187 root/dynamic/templates/administration/settings/index.tt:202 root/dynamic/templates/administration/settings/index.tt:219 root/dynamic/templates/administration/settings/index.tt:256 root/dynamic/templates/administration/settings/index.tt:267 root/dynamic/templates/administration/settings/index.tt:37 root/dynamic/templates/administration/settings/index.tt:48 root/dynamic/templates/administration/settings/index.tt:59 root/dynamic/templates/administration/settings/index.tt:70 root/dynamic/templates/public/index.tt:144
 msgid "Minutes"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:142 root/dynamic/templates/administration/index.tt:504
+#: root/dynamic/templates/administration/index.tt:149 root/dynamic/templates/administration/index.tt:514
 msgid "Modify time"
 msgstr ""
 
@@ -547,103 +559,103 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:116 root/dynamic/templates/administration/index.tt:190 root/dynamic/templates/administration/index.tt:41
+#: root/dynamic/templates/administration/index.tt:119 root/dynamic/templates/administration/index.tt:197 root/dynamic/templates/administration/index.tt:40
 msgid "Multiple guests"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:124 root/dynamic/templates/administration/index.tt:279 root/dynamic/templates/administration/index.tt:436
+#: root/dynamic/templates/administration/index.tt:127 root/dynamic/templates/administration/index.tt:287 root/dynamic/templates/administration/index.tt:446
 msgid "Name"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:115 root/dynamic/templates/administration/index.tt:189 root/dynamic/templates/administration/index.tt:40
+#: root/dynamic/templates/administration/index.tt:118 root/dynamic/templates/administration/index.tt:196 root/dynamic/templates/administration/index.tt:39
 msgid "New guest"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:370
+#: root/dynamic/templates/administration/index.tt:380
 msgid "New guest batch created"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:336
+#: root/dynamic/templates/administration/index.tt:346
 msgid "New guest user created"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:113 root/dynamic/templates/administration/index.tt:187 root/dynamic/templates/administration/index.tt:259 root/dynamic/templates/administration/index.tt:38
+#: root/dynamic/templates/administration/index.tt:116 root/dynamic/templates/administration/index.tt:194 root/dynamic/templates/administration/index.tt:266 root/dynamic/templates/administration/index.tt:37
 msgid "New user"
 msgstr ""
 
-#: root/dynamic/templates/administration/history/statistics.tt:50
+#: root/dynamic/templates/administration/history/statistics.tt:48
 msgid "No location set"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:134 root/dynamic/templates/administration/index.tt:472 root/dynamic/templates/administration/index.tt:56
+#: root/dynamic/templates/administration/index.tt:141 root/dynamic/templates/administration/index.tt:482 root/dynamic/templates/administration/index.tt:59
 msgid "Notes"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:383
+#: root/dynamic/templates/administration/index.tt:393
 msgid "Number of accounts created"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:202
+#: root/dynamic/templates/administration/index.tt:209
 msgid "Pages"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:460
+#: root/dynamic/templates/administration/settings/index.tt:478
 msgid "Passes"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:456
+#: root/dynamic/templates/administration/settings/index.tt:474
 msgid "Passes to create per batch"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:301 root/dynamic/templates/administration/index.tt:302 root/dynamic/templates/administration/index.tt:349 root/dynamic/templates/administration/index.tt:576 root/dynamic/templates/administration/index.tt:577 root/dynamic/templates/administration/index.tt:67 root/dynamic/templates/login.tt:45 root/dynamic/templates/public/index.tt:101 root/dynamic/templates/public/index.tt:66
+#: root/dynamic/templates/administration/index.tt:311 root/dynamic/templates/administration/index.tt:312 root/dynamic/templates/administration/index.tt:359 root/dynamic/templates/administration/index.tt:590 root/dynamic/templates/administration/index.tt:591 root/dynamic/templates/administration/index.tt:70 root/dynamic/templates/login.tt:45 root/dynamic/templates/public/index.tt:100 root/dynamic/templates/public/index.tt:65
 msgid "Password"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:979
+#: root/dynamic/templates/administration/index.tt:993
 msgid "Password changed."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:305 root/dynamic/templates/administration/index.tt:582
+#: root/dynamic/templates/administration/index.tt:315 root/dynamic/templates/administration/index.tt:596
 msgid "Password fields must match."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:104 root/dynamic/templates/public/index.tt:69
+#: root/dynamic/templates/public/index.tt:103 root/dynamic/templates/public/index.tt:68
 msgid "Password is required"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:477
+#: root/dynamic/templates/administration/settings/index.tt:495
 msgid "Password label"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:310
+#: root/dynamic/templates/administration/index.tt:320
 msgid "Passwords do not match"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:307
+#: root/dynamic/templates/administration/index.tt:317
 msgid "Passwords match"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:501
+#: root/dynamic/templates/administration/settings/index.tt:519
 msgid "Patron hyperlinks"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:385 root/dynamic/templates/administration/settings/index.tt:396 root/dynamic/templates/administration/settings/index.tt:422 root/dynamic/templates/administration/settings/index.tt:433
+#: root/dynamic/templates/administration/settings/index.tt:403 root/dynamic/templates/administration/settings/index.tt:414 root/dynamic/templates/administration/settings/index.tt:440 root/dynamic/templates/administration/settings/index.tt:451
 msgid "Pixels"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:448
+#: root/dynamic/templates/administration/settings/index.tt:466
 msgid "Prefix for guest passes"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:452
+#: root/dynamic/templates/administration/settings/index.tt:470
 msgid "Prefix for guest passes, defaults to 'guest' if none is specified."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:216
+#: root/dynamic/templates/administration/index.tt:223
 msgid "Print"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1220
+#: root/dynamic/templates/administration/index.tt:1234
 msgid "Print job refreshed"
 msgstr ""
 
@@ -651,27 +663,27 @@ msgstr ""
 msgid "Print job retention"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:18 root/dynamic/templates/administration/settings/index.tt:533
+#: root/dynamic/templates/administration/settings/index.tt:18 root/dynamic/templates/administration/settings/index.tt:551
 msgid "Print management"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:200
+#: root/dynamic/templates/administration/index.tt:207
 msgid "Printer"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:536
+#: root/dynamic/templates/administration/settings/index.tt:554
 msgid "Printer configuration"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:14
+#: root/dynamic/templates/administration/index.tt:13
 msgid "Prints"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:558
+#: root/dynamic/templates/administration/settings/index.tt:576
 msgid "Public interface JavaScript"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:172 root/dynamic/templates/administration/index.tt:224 root/dynamic/templates/administration/index.tt:28 root/dynamic/templates/administration/index.tt:98
+#: root/dynamic/templates/administration/index.tt:101 root/dynamic/templates/administration/index.tt:179 root/dynamic/templates/administration/index.tt:231 root/dynamic/templates/administration/index.tt:27
 msgid "Refresh"
 msgstr ""
 
@@ -679,15 +691,15 @@ msgstr ""
 msgid "Renew the time allotment when it reaches zero"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1139 root/dynamic/templates/public/index.tt:378
+#: root/dynamic/templates/administration/index.tt:1153 root/dynamic/templates/public/index.tt:377
 msgid "Reservation canceled."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:257
+#: root/dynamic/templates/public/index.tt:256
 msgid "Reservation created."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1047
+#: root/dynamic/templates/administration/index.tt:1061
 msgid "Reservation for user created."
 msgstr ""
 
@@ -695,7 +707,7 @@ msgstr ""
 msgid "Reservation only. A patron must place a reservation for a client before logging in to it."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:26
+#: root/dynamic/templates/public/index.tt:25
 msgid "Reservation status"
 msgstr ""
 
@@ -707,31 +719,31 @@ msgstr ""
 msgid "Reservations"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:143
+#: root/dynamic/templates/administration/index.tt:150
 msgid "Reserve"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:136 root/dynamic/templates/public/index.tt:153
+#: root/dynamic/templates/administration/index.tt:143 root/dynamic/templates/public/index.tt:152
 msgid "Reserved"
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:150
+#: root/dynamic/templates/public/index.tt:149
 msgid "Reserved by"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:421
+#: root/dynamic/templates/administration/index.tt:431
 msgid "Roles"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:514
+#: root/dynamic/templates/administration/settings/index.tt:532
 msgid "SIP configuration"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:132 root/dynamic/templates/administration/index.tt:54
+#: root/dynamic/templates/administration/index.tt:139 root/dynamic/templates/administration/index.tt:57
 msgid "Session minutes"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:126
+#: root/dynamic/templates/administration/index.tt:129
 msgid "Session status"
 msgstr ""
 
@@ -739,15 +751,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:602
+#: root/dynamic/templates/administration/settings/index.tt:620
 msgid "Settings not updated."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:599
+#: root/dynamic/templates/administration/settings/index.tt:617
 msgid "Settings updated."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:370 root/dynamic/templates/administration/settings/index.tt:407
+#: root/dynamic/templates/administration/settings/index.tt:388 root/dynamic/templates/administration/settings/index.tt:425
 msgid "Source URL"
 msgstr ""
 
@@ -759,7 +771,7 @@ msgstr ""
 msgid "Statistics and history for users older than this number of days will be automatically anonymized. If not set, data will never be anonymized."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:199 root/dynamic/templates/administration/index.tt:464 root/dynamic/templates/administration/index.tt:55 root/dynamic/templates/public/index.tt:24
+#: root/dynamic/templates/administration/index.tt:206 root/dynamic/templates/administration/index.tt:474 root/dynamic/templates/administration/index.tt:58 root/dynamic/templates/public/index.tt:23
 msgid "Status"
 msgstr ""
 
@@ -767,7 +779,7 @@ msgstr ""
 msgid "Success:"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:485
+#: root/dynamic/templates/administration/index.tt:495
 msgid "Super administrator"
 msgstr ""
 
@@ -783,15 +795,15 @@ msgstr ""
 msgid "Terms of service text"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:377 root/dynamic/templates/administration/settings/index.tt:414
+#: root/dynamic/templates/administration/settings/index.tt:395 root/dynamic/templates/administration/settings/index.tt:432
 msgid "The URL for the source image or image service."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:399 root/dynamic/templates/administration/settings/index.tt:436
+#: root/dynamic/templates/administration/settings/index.tt:417 root/dynamic/templates/administration/settings/index.tt:454
 msgid "The height of the source image or image service in pixels."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:463
+#: root/dynamic/templates/administration/settings/index.tt:481
 msgid "The number of passes to create per batch."
 msgstr ""
 
@@ -799,35 +811,35 @@ msgstr ""
 msgid "The size of the time window a patron has to log in to a client. If the patron does not do so his or her reservation will be canceled."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:482
+#: root/dynamic/templates/administration/settings/index.tt:500
 msgid "The text in this field will be prepended to the guest password, for example <i>Password:</i>. This field is displayed in monospace for ease of formatting."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:472
+#: root/dynamic/templates/administration/settings/index.tt:490
 msgid "The text in this field will be prepended to the guest username, for example <i>Username:</i>. This field is displayed in monospace for ease of formatting."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:388 root/dynamic/templates/administration/settings/index.tt:425
+#: root/dynamic/templates/administration/settings/index.tt:406 root/dynamic/templates/administration/settings/index.tt:443
 msgid "The width of the source image or image service in pixels."
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:578
+#: root/dynamic/templates/administration/settings/index.tt:596
 msgid "These rules override the default time allowances"
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:224 root/dynamic/templates/public/index.tt:277
+#: root/dynamic/templates/public/index.tt:223 root/dynamic/templates/public/index.tt:276
 msgid "This client is already reserved."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:351
+#: root/dynamic/templates/public/index.tt:350
 msgid "This client is not currently reserved."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:268
+#: root/dynamic/templates/public/index.tt:267
 msgid "This kiosk is closed for the day."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:25
+#: root/dynamic/templates/public/index.tt:24
 msgid "Time remaining"
 msgstr ""
 
@@ -839,79 +851,79 @@ msgstr ""
 msgid "Timestamp"
 msgstr ""
 
-#: root/dynamic/templates/administration/history/statistics.tt:23 root/dynamic/templates/administration/history/statistics.tt:26
+#: root/dynamic/templates/administration/history/statistics.tt:21 root/dynamic/templates/administration/history/statistics.tt:24
 msgid "To"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:367
+#: root/dynamic/templates/administration/settings/index.tt:385
 msgid "Top banner"
 msgstr ""
 
-#: root/dynamic/templates/administration/history/statistics.tt:56
+#: root/dynamic/templates/administration/history/statistics.tt:54
 msgid "Total by date"
 msgstr ""
 
-#: root/dynamic/templates/administration/history/statistics.tt:77
+#: root/dynamic/templates/administration/history/statistics.tt:75
 msgid "Total by location"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:135 root/dynamic/templates/administration/index.tt:57 root/dynamic/templates/administration/index.tt:69
+#: root/dynamic/templates/administration/index.tt:142 root/dynamic/templates/administration/index.tt:60 root/dynamic/templates/administration/index.tt:72
 msgid "Troublemaker"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:992
+#: root/dynamic/templates/administration/index.tt:1006
 msgid "Troublemaker status switched."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:198
+#: root/dynamic/templates/administration/index.tt:205
 msgid "Type"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1143
+#: root/dynamic/templates/administration/index.tt:1157
 msgid "Unable to cancel reservation."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:982
+#: root/dynamic/templates/administration/index.tt:996
 msgid "Unable to change password."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:846 root/dynamic/templates/administration/index.tt:869
+#: root/dynamic/templates/administration/index.tt:860 root/dynamic/templates/administration/index.tt:883
 msgid "Unable to create guest user."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1113
+#: root/dynamic/templates/administration/index.tt:1127
 msgid "Unable to delete user."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1127
+#: root/dynamic/templates/administration/index.tt:1141
 msgid "Unable to log user out."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1055
+#: root/dynamic/templates/administration/index.tt:1069
 msgid "Unable to modify reservation: Reason unknown."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1051
+#: root/dynamic/templates/administration/index.tt:1065
 msgid "Unable to modify reservation: User already has a reservation for a different client."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1053
+#: root/dynamic/templates/administration/index.tt:1067
 msgid "Unable to modify reservation: User not found."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:995
+#: root/dynamic/templates/administration/index.tt:1009
 msgid "Unable to switch troublemaker status."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1025
+#: root/dynamic/templates/administration/index.tt:1039
 msgid "Unable to update user's time."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:938
+#: root/dynamic/templates/administration/index.tt:952
 msgid "Unable to update user."
 msgstr ""
 
-#: root/dynamic/templates/administration/hours/index.tt:80 root/dynamic/templates/administration/settings/index.tt:586
+#: root/dynamic/templates/administration/hours/index.tt:80 root/dynamic/templates/administration/settings/index.tt:604
 msgid "Update"
 msgstr ""
 
@@ -919,11 +931,11 @@ msgstr ""
 msgid "Update hours for all locations."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:525
+#: root/dynamic/templates/administration/index.tt:535
 msgid "Update time"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:494
+#: root/dynamic/templates/administration/index.tt:504
 msgid "Update user"
 msgstr ""
 
@@ -931,7 +943,7 @@ msgstr ""
 msgid "Useful for implementing <a href='https://eugdpr.org/' target='_blank'>GDPR</a>"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:204
+#: root/dynamic/templates/administration/index.tt:211
 msgid "User"
 msgstr ""
 
@@ -939,15 +951,15 @@ msgstr ""
 msgid "User categories"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:821
+#: root/dynamic/templates/administration/index.tt:835
 msgid "User created."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1109
+#: root/dynamic/templates/administration/index.tt:1123
 msgid "User deleted."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:824
+#: root/dynamic/templates/administration/index.tt:838
 msgid "User not created."
 msgstr ""
 
@@ -955,11 +967,11 @@ msgstr ""
 msgid "User settings"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:133
+#: root/dynamic/templates/administration/index.tt:140
 msgid "User status"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:935
+#: root/dynamic/templates/administration/index.tt:949
 msgid "User updated."
 msgstr ""
 
@@ -967,59 +979,59 @@ msgstr ""
 msgid "User's client is reserved"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:1022
+#: root/dynamic/templates/administration/index.tt:1036
 msgid "User's time updated."
 msgstr ""
 
-#: root/dynamic/templates/administration/history/index.tt:6 root/dynamic/templates/administration/index.tt:127 root/dynamic/templates/administration/index.tt:267 root/dynamic/templates/administration/index.tt:268 root/dynamic/templates/administration/index.tt:344 root/dynamic/templates/administration/index.tt:430 root/dynamic/templates/administration/index.tt:49 root/dynamic/templates/administration/index.tt:545 root/dynamic/templates/login.tt:23 root/dynamic/templates/login.tt:27 root/dynamic/templates/public/index.tt:58
+#: root/dynamic/templates/administration/history/index.tt:6 root/dynamic/templates/administration/index.tt:130 root/dynamic/templates/administration/index.tt:274 root/dynamic/templates/administration/index.tt:275 root/dynamic/templates/administration/index.tt:354 root/dynamic/templates/administration/index.tt:440 root/dynamic/templates/administration/index.tt:48 root/dynamic/templates/administration/index.tt:555 root/dynamic/templates/login.tt:23 root/dynamic/templates/login.tt:27 root/dynamic/templates/public/index.tt:57
 msgid "Username"
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:261
+#: root/dynamic/templates/public/index.tt:260
 msgid "Username & password do not match."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:274
+#: root/dynamic/templates/administration/index.tt:281
 msgid "Username already used"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:549
+#: root/dynamic/templates/administration/index.tt:559
 msgid "Username is invalid"
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:61
+#: root/dynamic/templates/public/index.tt:60
 msgid "Username is required"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:271
+#: root/dynamic/templates/administration/index.tt:278
 msgid "Username is unique"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:467
+#: root/dynamic/templates/administration/settings/index.tt:485
 msgid "Username label"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:432
+#: root/dynamic/templates/administration/index.tt:442
 msgid "Username may not be edited."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:269
+#: root/dynamic/templates/administration/index.tt:276
 msgid "Username must be unique."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:547
+#: root/dynamic/templates/administration/index.tt:557
 msgid "Username of user to make reservation for."
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:7
+#: root/dynamic/templates/administration/index.tt:6
 msgid "Users"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:240
+#: root/dynamic/templates/administration/index.tt:247
 msgid "View"
 msgstr ""
 
-#: root/dynamic/templates/administration/index.tt:392
+#: root/dynamic/templates/administration/index.tt:402
 msgid "View & print guest passes"
 msgstr ""
 
@@ -1039,96 +1051,100 @@ msgstr ""
 msgid "When extending time"
 msgstr ""
 
-#: root/dynamic/templates/administration/settings/index.tt:381 root/dynamic/templates/administration/settings/index.tt:418
+#: root/dynamic/templates/administration/settings/index.tt:399 root/dynamic/templates/administration/settings/index.tt:436
 msgid "Width"
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:325
+#: root/dynamic/templates/public/index.tt:324
 msgid "You are not of the appropriate age to use this client."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:274
+#: root/dynamic/templates/public/index.tt:273
 msgid "You have already reserved a client."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:271
+#: root/dynamic/templates/public/index.tt:270
 msgid "You have already reserved this client."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:319
+#: root/dynamic/templates/public/index.tt:318
 msgid "You have an overdue item recall."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:322
+#: root/dynamic/templates/public/index.tt:321
 msgid "You have been billed for too many items."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:307
+#: root/dynamic/templates/public/index.tt:306
 msgid "You have claimed returned for too many items."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:280
+#: root/dynamic/templates/public/index.tt:279
 msgid "You have excessive oustanding fees."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:316
+#: root/dynamic/templates/public/index.tt:315
 msgid "You have excessive outstanding fees."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:313
+#: root/dynamic/templates/public/index.tt:312
 msgid "You have excessive outstanding fines."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:310
+#: root/dynamic/templates/public/index.tt:309
 msgid "You have lost too many items."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:265
+#: root/dynamic/templates/public/index.tt:264
 msgid "You have no time remaining."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:304
+#: root/dynamic/templates/public/index.tt:303
 msgid "You have renewed too many items."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:298
+#: root/dynamic/templates/public/index.tt:297
 msgid "You have too many items checked out."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:301
+#: root/dynamic/templates/public/index.tt:300
 msgid "You have too many overdue items."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:283
+#: root/dynamic/templates/public/index.tt:282
 msgid "Your checkout privileges have been denied."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:292
+#: root/dynamic/templates/public/index.tt:291
 msgid "Your hold privileges have been denied."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:295
+#: root/dynamic/templates/public/index.tt:294
 msgid "Your library card has been reported lost or stolen."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:289
+#: root/dynamic/templates/public/index.tt:288
 msgid "Your recall privileges have been denied."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:286
+#: root/dynamic/templates/public/index.tt:285
 msgid "Your renewal privileges have been denied."
 msgstr ""
 
-#: root/dynamic/templates/public/index.tt:382
+#: root/dynamic/templates/public/index.tt:381
 msgid "Your reservation cancelation failed for an unknown reason."
+msgstr ""
+
+#: root/dynamic/templates/administration/hours/index.tt:0
+msgid "d"
 msgstr ""
 
 #: root/dynamic/templates/administration/hours/index.tt:140 root/dynamic/templates/administration/hours/index.tt:99
 msgid "for"
 msgstr ""
 
-#: root/dynamic/includes/language_menu.tt:8
-msgid "lang.$lang"
+#: root/dynamic/includes/breadcrumbs.tt:5 root/dynamic/includes/breadcrumbs.tt:9
+msgid "item.label"
 msgstr ""
 
 # Not generated by xgettext.pl

--- a/lib/Libki/I18N/sv.po
+++ b/lib/Libki/I18N/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2019-08-07 20:41+0200\n"
+"PO-Revision-Date: 2019-08-25 18:02+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: sv_SE\n"
@@ -17,10 +17,9 @@ msgstr ""
 "X-Generator: Poedit 2.2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: root/dynamic/templates/administration/hours/index.tt:31
-#: root/dynamic/templates/administration/hours/index.tt:57
-msgid "$d"
-msgstr "$d"
+#: root/dynamic/includes/language_menu.tt:0
+msgid "('lang.' _ lang)"
+msgstr "('lang.' _ lang)"
 
 #: root/dynamic/templates/administration/history/index.tt:8
 msgid "Action"
@@ -30,7 +29,7 @@ msgstr "Händelse"
 msgid "Add"
 msgstr "Lägg till"
 
-#: root/dynamic/templates/administration/index.tt:516
+#: root/dynamic/templates/administration/index.tt:526
 msgid ""
 "Add a + or - sign to increment or decrement the existing amount of time."
 msgstr ""
@@ -40,15 +39,15 @@ msgstr ""
 msgid "Add closing hours for specific dates"
 msgstr "Lägg till stängningstid för specifika datum"
 
-#: root/dynamic/templates/administration/settings/index.tt:491
+#: root/dynamic/templates/administration/settings/index.tt:509
 msgid "Add custom CSS for batch guest passes here."
 msgstr "Lägg till egen CSS för batchskapandet av gästpass här."
 
-#: root/dynamic/templates/administration/settings/index.tt:554
+#: root/dynamic/templates/administration/settings/index.tt:572
 msgid "Add custom JavaScript for the administration interface here."
 msgstr "Lägg till eget javascript för administrationsdelen här."
 
-#: root/dynamic/templates/administration/settings/index.tt:562
+#: root/dynamic/templates/administration/settings/index.tt:580
 msgid "Add custom JavaScript for the public web interface here."
 msgstr "Lägg till eget javascript för den offentliga delen här."
 
@@ -69,7 +68,7 @@ msgstr "Administration / Öppettider"
 msgid "Administration / History"
 msgstr "Administration / Historik"
 
-#: root/dynamic/templates/administration/history/statistics.tt:5
+#: root/dynamic/templates/administration/history/statistics.tt:3
 msgid "Administration / History / Statistics"
 msgstr "Administration / Historik / Statistik"
 
@@ -77,20 +76,20 @@ msgstr "Administration / Historik / Statistik"
 msgid "Administration / Settings"
 msgstr "Administration / inställningar"
 
-#: root/dynamic/templates/administration/settings/index.tt:550
+#: root/dynamic/templates/administration/settings/index.tt:568
 msgid "Administration interface JavaScript"
 msgstr "Administrationsdelens javascript"
 
-#: root/dynamic/templates/administration/index.tt:480
+#: root/dynamic/templates/administration/index.tt:490
 msgid "Administrator"
 msgstr "Administratör"
 
-#: root/dynamic/templates/administration/settings/index.tt:572
+#: root/dynamic/templates/administration/settings/index.tt:590
 msgid "Advanced rules"
 msgstr "Avancerade regler"
 
 #: root/dynamic/templates/administration/settings/index.tt:22
-#: root/dynamic/templates/administration/settings/index.tt:569
+#: root/dynamic/templates/administration/settings/index.tt:587
 msgid "Advanced settings"
 msgstr "Avancerade inställningar"
 
@@ -98,9 +97,9 @@ msgstr "Avancerade inställningar"
 msgid "Alert:"
 msgstr "Varning:"
 
-#: root/dynamic/templates/administration/index.tt:156
-#: root/dynamic/templates/administration/index.tt:82
-#: root/dynamic/templates/public/index.tt:10
+#: root/dynamic/templates/administration/index.tt:163
+#: root/dynamic/templates/administration/index.tt:85
+#: root/dynamic/templates/public/index.tt:9
 msgid "All"
 msgstr "Alla"
 
@@ -134,15 +133,15 @@ msgstr "Mängden tid användarens passtid automatiskt förlängs med."
 msgid "Any client is reserved"
 msgstr "Vilken dator som helst är reserverad"
 
-#: root/dynamic/templates/administration/index.tt:1136
+#: root/dynamic/templates/administration/index.tt:1150
 msgid "Are you sure you want to cancel the reservation for this client?"
 msgstr "Är du säker på att du till avbryta reservationen på den här datorn?"
 
-#: root/dynamic/templates/administration/index.tt:1106
+#: root/dynamic/templates/administration/index.tt:1120
 msgid "Are you sure you want to delete this user?"
 msgstr "Är du säker på att du vill radera den här användaren?"
 
-#: root/dynamic/templates/administration/index.tt:1120
+#: root/dynamic/templates/administration/index.tt:1134
 msgid "Are you sure you want to log this user out?"
 msgstr "Är du säker på att du vill logga ut den här användaren?"
 
@@ -151,47 +150,47 @@ msgstr "Är du säker på att du vill logga ut den här användaren?"
 msgid "Automatic time extension"
 msgstr "Automatisk tidsförlängning"
 
-#: root/dynamic/templates/public/index.tt:141
+#: root/dynamic/templates/public/index.tt:140
 msgid "Available"
 msgstr "Ledig"
 
-#: root/dynamic/templates/administration/settings/index.tt:404
+#: root/dynamic/templates/administration/settings/index.tt:422
 msgid "Bottom banner"
 msgstr "Nedre banner"
 
-#: root/dynamic/templates/administration/index.tt:248
-#: root/dynamic/templates/administration/index.tt:325
-#: root/dynamic/templates/administration/index.tt:493
-#: root/dynamic/templates/administration/index.tt:524
-#: root/dynamic/templates/administration/index.tt:555
-#: root/dynamic/templates/administration/index.tt:587
-#: root/dynamic/templates/public/index.tt:110
-#: root/dynamic/templates/public/index.tt:75
+#: root/dynamic/templates/administration/index.tt:255
+#: root/dynamic/templates/administration/index.tt:335
+#: root/dynamic/templates/administration/index.tt:503
+#: root/dynamic/templates/administration/index.tt:534
+#: root/dynamic/templates/administration/index.tt:565
+#: root/dynamic/templates/administration/index.tt:601
+#: root/dynamic/templates/public/index.tt:109
+#: root/dynamic/templates/public/index.tt:74
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: root/dynamic/templates/public/index.tt:111
-#: root/dynamic/templates/public/index.tt:38
-#: root/dynamic/templates/public/index.tt:91
+#: root/dynamic/templates/public/index.tt:110
+#: root/dynamic/templates/public/index.tt:37
+#: root/dynamic/templates/public/index.tt:90
 msgid "Cancel reservation"
 msgstr "Avbryt reservation"
 
-#: root/dynamic/templates/administration/index.tt:130
-#: root/dynamic/templates/administration/index.tt:291
-#: root/dynamic/templates/administration/index.tt:448
-#: root/dynamic/templates/administration/index.tt:52
+#: root/dynamic/templates/administration/index.tt:136
+#: root/dynamic/templates/administration/index.tt:300
+#: root/dynamic/templates/administration/index.tt:458
+#: root/dynamic/templates/administration/index.tt:54
 msgid "Category"
 msgstr "Kategori"
 
-#: root/dynamic/templates/administration/index.tt:566
-#: root/dynamic/templates/administration/index.tt:588
+#: root/dynamic/templates/administration/index.tt:580
+#: root/dynamic/templates/administration/index.tt:602
 msgid "Change password"
 msgstr "Ändra lösenord"
 
 #: root/dynamic/templates/administration/history/index.tt:7
-#: root/dynamic/templates/administration/index.tt:203
-#: root/dynamic/templates/administration/index.tt:58
-#: root/dynamic/templates/public/index.tt:22
+#: root/dynamic/templates/administration/index.tt:210
+#: root/dynamic/templates/administration/index.tt:61
+#: root/dynamic/templates/public/index.tt:21
 msgid "Client"
 msgstr "Dator"
 
@@ -212,7 +211,7 @@ msgstr "Inaktivitetsutloggning"
 msgid "Client inactivity warning"
 msgstr "Inaktivitetsvarning"
 
-#: root/dynamic/templates/administration/settings/index.tt:364
+#: root/dynamic/templates/administration/settings/index.tt:382
 msgid "Client login banner settings"
 msgstr "Inställningar för datorernas loginskärm"
 
@@ -232,11 +231,11 @@ msgstr "Tidsgräns för datorernas uppdateringsfrekvens"
 msgid "Client reservations"
 msgstr "Datorreservationer"
 
-#: root/dynamic/templates/administration/index.tt:59
+#: root/dynamic/templates/administration/index.tt:62
 msgid "Client status"
 msgstr "Datorstatus"
 
-#: root/dynamic/templates/administration/index.tt:10
+#: root/dynamic/templates/administration/index.tt:9
 msgid "Clients"
 msgstr "Datorer"
 
@@ -245,9 +244,9 @@ msgstr "Datorer"
 msgid "Closing hours"
 msgstr "Öppettider"
 
-#: root/dynamic/templates/administration/index.tt:304
-#: root/dynamic/templates/administration/index.tt:580
-#: root/dynamic/templates/administration/index.tt:581
+#: root/dynamic/templates/administration/index.tt:314
+#: root/dynamic/templates/administration/index.tt:594
+#: root/dynamic/templates/administration/index.tt:595
 msgid "Confirm password"
 msgstr "Bekräfta lösenord"
 
@@ -267,29 +266,29 @@ msgstr ""
 "Bestäm om användarens automatiska tidsförlängning använder tid från den "
 "tidsmängd hen har för dagen eller om de extra minuterna är \"gratis\"."
 
-#: root/dynamic/templates/administration/index.tt:326
+#: root/dynamic/templates/administration/index.tt:336
 msgid "Create user"
 msgstr "Skapa användare"
 
-#: root/dynamic/templates/administration/index.tt:205
+#: root/dynamic/templates/administration/index.tt:212
 msgid "Created"
 msgstr "Skapad"
 
 #: root/dynamic/templates/administration/settings/index.tt:14
-#: root/dynamic/templates/administration/settings/index.tt:547
+#: root/dynamic/templates/administration/settings/index.tt:565
 msgid "Custom JavaScript"
 msgstr "Eget javascript"
 
-#: root/dynamic/templates/administration/index.tt:131
-#: root/dynamic/templates/administration/index.tt:53
+#: root/dynamic/templates/administration/index.tt:138
+#: root/dynamic/templates/administration/index.tt:56
 msgid "Daily minutes"
 msgstr "Minuter per dag"
 
-#: root/dynamic/templates/administration/history/statistics.tt:39
+#: root/dynamic/templates/administration/history/statistics.tt:37
 msgid "Daily usage"
 msgstr "Användande per dag"
 
-#: root/dynamic/templates/administration/history/statistics.tt:41
+#: root/dynamic/templates/administration/history/statistics.tt:39
 msgid "Daily usage, count of daily logins by location"
 msgstr "Användande per dag, antal dagliga logins baserade på plats"
 
@@ -298,7 +297,7 @@ msgstr "Användande per dag, antal dagliga logins baserade på plats"
 msgid "Data retention"
 msgstr "Datalagring"
 
-#: root/dynamic/templates/administration/history/statistics.tt:44
+#: root/dynamic/templates/administration/history/statistics.tt:42
 msgid "Date"
 msgstr "Datum"
 
@@ -329,7 +328,7 @@ msgstr "Användares grundtid per dag"
 msgid "Default time allowance per session"
 msgstr "Användares grundtid per datorpass"
 
-#: root/dynamic/templates/administration/settings/index.tt:526
+#: root/dynamic/templates/administration/settings/index.tt:544
 msgid ""
 "Define LDAP configuration in YAML format. This setting may be overridden by "
 "a LDAP block in the Libki conf file."
@@ -337,7 +336,7 @@ msgstr ""
 "Definiera LDAP-konfiguration i YAML-format. Den här inställningen kan köras "
 "över av ett LDAP-block i Libkis conf-fil."
 
-#: root/dynamic/templates/administration/settings/index.tt:518
+#: root/dynamic/templates/administration/settings/index.tt:536
 msgid ""
 "Define SIP configuration in YAML format. This setting may be overridden by a "
 "SIP block in the Libki conf file."
@@ -346,11 +345,11 @@ msgstr ""
 "publika datorns konfigurationsfil. Inställningen där går före inställningen "
 "här."
 
-#: root/dynamic/templates/administration/settings/index.tt:540
+#: root/dynamic/templates/administration/settings/index.tt:558
 msgid "Define printer configuration in YAML format."
 msgstr "Skrivarinställningar i YAML-format."
 
-#: root/dynamic/templates/administration/index.tt:70
+#: root/dynamic/templates/administration/index.tt:73
 msgid "Delete"
 msgstr "Radera"
 
@@ -358,18 +357,22 @@ msgstr "Radera"
 msgid "Delete selected"
 msgstr "Radera markerad"
 
-#: root/dynamic/templates/administration/index.tt:418
+#: root/dynamic/templates/administration/index.tt:428
 msgid "Details"
 msgstr "Detaljer"
 
-#: root/dynamic/templates/administration/index.tt:467
+#: root/dynamic/templates/administration/index.tt:477
 msgid "Disabled"
 msgstr "Avstängd"
 
-#: root/dynamic/templates/administration/index.tt:360
-#: root/dynamic/templates/administration/index.tt:396
+#: root/dynamic/templates/administration/index.tt:370
+#: root/dynamic/templates/administration/index.tt:406
 msgid "Dismiss"
 msgstr "Avvisa"
+
+#: root/dynamic/templates/administration/settings/index.tt:361
+msgid "Display first and last names"
+msgstr "Visa för- och efternamn"
 
 #: root/dynamic/templates/administration/settings/index.tt:228
 msgid "Display usernames"
@@ -379,23 +382,23 @@ msgstr "Visa användarnamn"
 msgid "Don't take minutes from daily allotment"
 msgstr "Ta inte minuter från den dagliga tidsmängden"
 
-#: root/dynamic/templates/administration/index.tt:232
+#: root/dynamic/templates/administration/index.tt:239
 msgid "Download"
 msgstr "Ladda ner"
 
-#: root/dynamic/templates/administration/index.tt:65
+#: root/dynamic/templates/administration/index.tt:68
 msgid "Edit"
 msgstr "Ändra"
 
-#: root/dynamic/templates/administration/index.tt:407
+#: root/dynamic/templates/administration/index.tt:417
 msgid "Edit user"
 msgstr "Ändra användare"
 
-#: root/dynamic/templates/administration/index.tt:466
+#: root/dynamic/templates/administration/index.tt:476
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: root/dynamic/templates/administration/settings/index.tt:506
+#: root/dynamic/templates/administration/settings/index.tt:524
 msgid ""
 "Entering a url here will cause a username to become a hyperlink with the "
 "user's username at the end. Make sure to add <i>http://</i> or <i>https://</"
@@ -408,6 +411,10 @@ msgstr ""
 #: root/dynamic/includes/wrapper.tt:51
 msgid "Error:"
 msgstr "Fel:"
+
+#: root/dynamic/templates/administration/settings/index.tt:350
+msgid "Example:"
+msgstr "Exempel:"
 
 #: root/dynamic/templates/administration/settings/index.tt:270
 msgid ""
@@ -429,11 +436,11 @@ msgstr "Förläng tid såvida inte"
 msgid "Extension length"
 msgstr "Tidsförlängning"
 
-#: root/dynamic/templates/administration/index.tt:1211
+#: root/dynamic/templates/administration/index.tt:1225
 msgid "Failed to release print job: "
 msgstr "Misslyckades att släppa utskrift: "
 
-#: root/dynamic/templates/administration/index.tt:201
+#: root/dynamic/templates/administration/index.tt:208
 msgid "File name"
 msgstr "Filnamn"
 
@@ -453,17 +460,17 @@ msgid ""
 msgstr ""
 "Först till kvarn. Användaren sätter sig vid en ledig dator och loggar in."
 
-#: root/dynamic/templates/administration/index.tt:282
-#: root/dynamic/templates/administration/index.tt:439
+#: root/dynamic/templates/administration/index.tt:290
+#: root/dynamic/templates/administration/index.tt:449
 msgid "First name"
 msgstr "Förnamn"
 
-#: root/dynamic/templates/administration/index.tt:129
+#: root/dynamic/templates/administration/index.tt:133
 #: root/dynamic/templates/administration/index.tt:51
 msgid "Firstname"
 msgstr "Förnamn"
 
-#: root/dynamic/templates/administration/settings/index.tt:509
+#: root/dynamic/templates/administration/settings/index.tt:527
 msgid ""
 "For example, <i>http://catalog.koha.library/cgi-bin/koha/members/member.pl?"
 "quicksearch=1&searchmember=</i> will link to the Koha ILS's search function "
@@ -473,26 +480,26 @@ msgstr ""
 "quicksearch=1&searchmember=</i> kommer länka till Kohas sökfunktion för "
 "användarnamnet."
 
-#: root/dynamic/templates/administration/history/statistics.tt:13
-#: root/dynamic/templates/administration/history/statistics.tt:16
+#: root/dynamic/templates/administration/history/statistics.tt:11
+#: root/dynamic/templates/administration/history/statistics.tt:14
 msgid "From"
 msgstr "Från"
 
-#: root/dynamic/templates/administration/settings/index.tt:487
+#: root/dynamic/templates/administration/settings/index.tt:505
 msgid "Guest pass CSS"
 msgstr "Gästpass CSS"
 
 #: root/dynamic/templates/administration/settings/index.tt:16
-#: root/dynamic/templates/administration/settings/index.tt:445
+#: root/dynamic/templates/administration/settings/index.tt:463
 msgid "Guest passes"
 msgstr "Gästpass"
 
-#: root/dynamic/templates/administration/settings/index.tt:392
-#: root/dynamic/templates/administration/settings/index.tt:429
+#: root/dynamic/templates/administration/settings/index.tt:410
+#: root/dynamic/templates/administration/settings/index.tt:447
 msgid "Height"
 msgstr "Höjd"
 
-#: root/dynamic/templates/administration/index.tt:378
+#: root/dynamic/templates/administration/index.tt:388
 msgid "Highest guest account created"
 msgstr "Högsta gästkontonummer som skapats"
 
@@ -513,7 +520,7 @@ msgid "Home"
 msgstr "Hem"
 
 #: root/dynamic/templates/administration/settings/index.tt:17
-#: root/dynamic/templates/administration/settings/index.tt:498
+#: root/dynamic/templates/administration/settings/index.tt:516
 msgid "ILS integration"
 msgstr "Integrera med biblioteksdatasystemet"
 
@@ -525,10 +532,18 @@ msgstr ""
 "Om en Libkidator inte har kommunicerat med servern inom den här tiden så tas "
 "den bort från listan över aktiva datorer."
 
-#: root/dynamic/templates/administration/settings/index.tt:579
+#: root/dynamic/templates/administration/settings/index.tt:597
 msgid "If no match is found, the default time allowances will be used."
 msgstr ""
 "Om ingen matchning hittas kommer grundinställningen för tidsmängd användas."
+
+#: root/dynamic/templates/administration/settings/index.tt:362
+msgid ""
+"If not checked, the possibility to enter users' first and last name will "
+"disappear."
+msgstr ""
+"Om den här rutan inte är ikryssad försvinner möjligheten att lägga in användares "
+"för- och efternamn."
 
 #: root/dynamic/templates/administration/settings/index.tt:335
 msgid ""
@@ -538,7 +553,7 @@ msgstr ""
 "Om användaravtalstext läggs till här så kommer det visas i en dialogruta på "
 "datorn innan man tillåts logga in."
 
-#: root/dynamic/templates/public/index.tt:139
+#: root/dynamic/templates/public/index.tt:138
 msgid "In use"
 msgstr "Används"
 
@@ -546,7 +561,7 @@ msgstr "Används"
 msgid "Inactive user retention"
 msgstr "Lagring av inaktiva användare"
 
-#: root/dynamic/templates/public/index.tt:385
+#: root/dynamic/templates/public/index.tt:384
 msgid "Incorrect password."
 msgstr "Fel lösenord."
 
@@ -554,11 +569,11 @@ msgstr "Fel lösenord."
 msgid "Info:"
 msgstr "Info:"
 
-#: root/dynamic/templates/administration/index.tt:319
+#: root/dynamic/templates/administration/index.tt:329
 msgid "Is not a whole number"
 msgstr "Är inte ett heltal"
 
-#: root/dynamic/templates/administration/settings/index.tt:522
+#: root/dynamic/templates/administration/settings/index.tt:540
 msgid "LDAP configuration"
 msgstr "LDAP-konfiguration"
 
@@ -566,18 +581,18 @@ msgstr "LDAP-konfiguration"
 msgid "Language"
 msgstr "Språk"
 
-#: root/dynamic/templates/administration/index.tt:285
-#: root/dynamic/templates/administration/index.tt:442
+#: root/dynamic/templates/administration/index.tt:293
+#: root/dynamic/templates/administration/index.tt:452
 msgid "Last name"
 msgstr "Efternamn"
 
-#: root/dynamic/templates/administration/index.tt:128
+#: root/dynamic/templates/administration/index.tt:132
 #: root/dynamic/templates/administration/index.tt:50
 msgid "Lastname"
 msgstr "Efternamn"
 
-#: root/dynamic/templates/administration/index.tt:317
-#: root/dynamic/templates/administration/index.tt:460
+#: root/dynamic/templates/administration/index.tt:327
+#: root/dynamic/templates/administration/index.tt:470
 msgid "Leave unmodified for default amount of time."
 msgstr "Ändra oförändrat för grundinställningen för tid."
 
@@ -610,15 +625,15 @@ msgstr ""
 msgid "Libki Kiosk Management System"
 msgstr "Libki datorhanteringssystem"
 
-#: root/dynamic/templates/administration/history/statistics.tt:33
+#: root/dynamic/templates/administration/history/statistics.tt:31
 msgid "Limit"
 msgstr "Avgränsa"
 
-#: root/dynamic/templates/administration/index.tt:125
-#: root/dynamic/templates/administration/index.tt:153
-#: root/dynamic/templates/administration/index.tt:79
-#: root/dynamic/templates/public/index.tt:23
-#: root/dynamic/templates/public/index.tt:7
+#: root/dynamic/templates/administration/index.tt:128
+#: root/dynamic/templates/administration/index.tt:160
+#: root/dynamic/templates/administration/index.tt:82
+#: root/dynamic/templates/public/index.tt:22
+#: root/dynamic/templates/public/index.tt:6
 msgid "Location"
 msgstr "Plats"
 
@@ -628,7 +643,7 @@ msgid "Log in"
 msgstr "Logga in"
 
 #: root/dynamic/includes/navbar_administration.tt:36
-#: root/dynamic/templates/administration/index.tt:144
+#: root/dynamic/templates/administration/index.tt:151
 msgid "Log out"
 msgstr "Logga ut"
 
@@ -638,18 +653,18 @@ msgstr ""
 "Logga ut användaren automatiskt om hen inte varit aktiv på så här många "
 "minuter."
 
-#: root/dynamic/templates/administration/index.tt:1123
+#: root/dynamic/templates/administration/index.tt:1137
 msgid "Logged user out."
 msgstr "Loggade ut användaren."
 
-#: root/dynamic/templates/administration/index.tt:535
-#: root/dynamic/templates/administration/index.tt:556
-#: root/dynamic/templates/public/index.tt:34
-#: root/dynamic/templates/public/index.tt:76
+#: root/dynamic/templates/administration/index.tt:545
+#: root/dynamic/templates/administration/index.tt:566
+#: root/dynamic/templates/public/index.tt:33
+#: root/dynamic/templates/public/index.tt:75
 msgid "Make reservation"
 msgstr "Reservera"
 
-#: root/dynamic/templates/public/index.tt:48
+#: root/dynamic/templates/public/index.tt:47
 msgid "Make reservation for"
 msgstr "Reservera till"
 
@@ -657,11 +672,11 @@ msgstr "Reservera till"
 msgid "Manage existing specific dates"
 msgstr "Hantera redan bestämda datum"
 
-#: root/dynamic/templates/administration/index.tt:315
-#: root/dynamic/templates/administration/index.tt:354
-#: root/dynamic/templates/administration/index.tt:388
-#: root/dynamic/templates/administration/index.tt:458
-#: root/dynamic/templates/administration/index.tt:514
+#: root/dynamic/templates/administration/index.tt:325
+#: root/dynamic/templates/administration/index.tt:364
+#: root/dynamic/templates/administration/index.tt:398
+#: root/dynamic/templates/administration/index.tt:468
+#: root/dynamic/templates/administration/index.tt:524
 #: root/dynamic/templates/administration/settings/index.tt:176
 #: root/dynamic/templates/administration/settings/index.tt:187
 #: root/dynamic/templates/administration/settings/index.tt:202
@@ -672,12 +687,12 @@ msgstr "Hantera redan bestämda datum"
 #: root/dynamic/templates/administration/settings/index.tt:48
 #: root/dynamic/templates/administration/settings/index.tt:59
 #: root/dynamic/templates/administration/settings/index.tt:70
-#: root/dynamic/templates/public/index.tt:145
+#: root/dynamic/templates/public/index.tt:144
 msgid "Minutes"
 msgstr "Minuter"
 
-#: root/dynamic/templates/administration/index.tt:142
-#: root/dynamic/templates/administration/index.tt:504
+#: root/dynamic/templates/administration/index.tt:149
+#: root/dynamic/templates/administration/index.tt:514
 msgid "Modify time"
 msgstr "Ändra tid"
 
@@ -685,128 +700,127 @@ msgstr "Ändra tid"
 msgid "More"
 msgstr "Mer"
 
-#: root/dynamic/templates/administration/index.tt:116
-#: root/dynamic/templates/administration/index.tt:190
-#: root/dynamic/templates/administration/index.tt:41
+#: root/dynamic/templates/administration/index.tt:119
+#: root/dynamic/templates/administration/index.tt:197
+#: root/dynamic/templates/administration/index.tt:40
 msgid "Multiple guests"
 msgstr "Flera gäster"
 
-#: root/dynamic/templates/administration/index.tt:124
-#: root/dynamic/templates/administration/index.tt:279
-#: root/dynamic/templates/administration/index.tt:436
+#: root/dynamic/templates/administration/index.tt:127
+#: root/dynamic/templates/administration/index.tt:287
+#: root/dynamic/templates/administration/index.tt:446
 msgid "Name"
 msgstr "Namn"
 
-#: root/dynamic/templates/administration/index.tt:115
-#: root/dynamic/templates/administration/index.tt:189
-#: root/dynamic/templates/administration/index.tt:40
+#: root/dynamic/templates/administration/index.tt:118
+#: root/dynamic/templates/administration/index.tt:196
+#: root/dynamic/templates/administration/index.tt:39
 msgid "New guest"
 msgstr "Ny gäst"
 
-#: root/dynamic/templates/administration/index.tt:370
+#: root/dynamic/templates/administration/index.tt:380
 msgid "New guest batch created"
 msgstr "Ny grupp av gäster skapad"
 
-#: root/dynamic/templates/administration/index.tt:336
+#: root/dynamic/templates/administration/index.tt:346
 msgid "New guest user created"
 msgstr "Ny gästanvändare skapad"
 
-#: root/dynamic/templates/administration/index.tt:113
-#: root/dynamic/templates/administration/index.tt:187
-#: root/dynamic/templates/administration/index.tt:259
-#: root/dynamic/templates/administration/index.tt:38
+#: root/dynamic/templates/administration/index.tt:116
+#: root/dynamic/templates/administration/index.tt:194
+#: root/dynamic/templates/administration/index.tt:266
+#: root/dynamic/templates/administration/index.tt:37
 msgid "New user"
 msgstr "Ny användare"
 
-#: root/dynamic/templates/administration/history/statistics.tt:50
+#: root/dynamic/templates/administration/history/statistics.tt:48
 msgid "No location set"
 msgstr "Ingen plats bestämd"
 
-#: root/dynamic/templates/administration/index.tt:134
-#: root/dynamic/templates/administration/index.tt:472
-#: root/dynamic/templates/administration/index.tt:56
+#: root/dynamic/templates/administration/index.tt:141
+#: root/dynamic/templates/administration/index.tt:482
+#: root/dynamic/templates/administration/index.tt:59
 msgid "Notes"
 msgstr "Anteckningar"
 
-#: root/dynamic/templates/administration/index.tt:383
+#: root/dynamic/templates/administration/index.tt:393
 msgid "Number of accounts created"
 msgstr "Antal konton skapade"
 
-#: root/dynamic/templates/administration/index.tt:202
+#: root/dynamic/templates/administration/index.tt:209
 msgid "Pages"
 msgstr "Sidor"
 
-#: root/dynamic/templates/administration/settings/index.tt:460
+#: root/dynamic/templates/administration/settings/index.tt:478
 msgid "Passes"
 msgstr "Konton"
 
-#: root/dynamic/templates/administration/settings/index.tt:456
+#: root/dynamic/templates/administration/settings/index.tt:474
 msgid "Passes to create per batch"
 msgstr "Konton att skapa per grupp"
 
-#: root/dynamic/templates/administration/index.tt:301
-#: root/dynamic/templates/administration/index.tt:302
-#: root/dynamic/templates/administration/index.tt:349
-#: root/dynamic/templates/administration/index.tt:576
-#: root/dynamic/templates/administration/index.tt:577
-#: root/dynamic/templates/administration/index.tt:67
+#: root/dynamic/templates/administration/index.tt:311
+#: root/dynamic/templates/administration/index.tt:312
+#: root/dynamic/templates/administration/index.tt:359
+#: root/dynamic/templates/administration/index.tt:590
+#: root/dynamic/templates/administration/index.tt:591
+#: root/dynamic/templates/administration/index.tt:70
 #: root/dynamic/templates/login.tt:45
-#: root/dynamic/templates/public/index.tt:101
-#: root/dynamic/templates/public/index.tt:66
+#: root/dynamic/templates/public/index.tt:100
+#: root/dynamic/templates/public/index.tt:65
 msgid "Password"
 msgstr "Lösenord"
 
-#: root/dynamic/templates/administration/index.tt:979
+#: root/dynamic/templates/administration/index.tt:993
 msgid "Password changed."
 msgstr "Lösenordet har ändrats."
 
-#: root/dynamic/templates/administration/index.tt:305
-#: root/dynamic/templates/administration/index.tt:582
+#: root/dynamic/templates/administration/index.tt:315
+#: root/dynamic/templates/administration/index.tt:596
 msgid "Password fields must match."
 msgstr "Lösenorden måste stämma överens."
 
-#: root/dynamic/templates/public/index.tt:104
-#: root/dynamic/templates/public/index.tt:69
+#: root/dynamic/templates/public/index.tt:103
+#: root/dynamic/templates/public/index.tt:68
 msgid "Password is required"
 msgstr "Ett lösenord krävs"
 
-#: root/dynamic/templates/administration/settings/index.tt:477
+#: root/dynamic/templates/administration/settings/index.tt:495
 msgid "Password label"
 msgstr "Lösenordsfält"
 
-#: root/dynamic/templates/administration/index.tt:310
+#: root/dynamic/templates/administration/index.tt:320
 msgid "Passwords do not match"
 msgstr "Lösenorden stämmer inte överens"
 
-#: root/dynamic/templates/administration/index.tt:307
+#: root/dynamic/templates/administration/index.tt:317
 msgid "Passwords match"
 msgstr "Lösenorden stämmer överens"
 
-#: root/dynamic/templates/administration/settings/index.tt:501
+#: root/dynamic/templates/administration/settings/index.tt:519
 msgid "Patron hyperlinks"
 msgstr "Hyperlänk till låntagaren"
 
-#: root/dynamic/templates/administration/settings/index.tt:385
-#: root/dynamic/templates/administration/settings/index.tt:396
-#: root/dynamic/templates/administration/settings/index.tt:422
-#: root/dynamic/templates/administration/settings/index.tt:433
+#: root/dynamic/templates/administration/settings/index.tt:403
+#: root/dynamic/templates/administration/settings/index.tt:414
+#: root/dynamic/templates/administration/settings/index.tt:440
+#: root/dynamic/templates/administration/settings/index.tt:451
 msgid "Pixels"
 msgstr "Pixlar"
 
-#: root/dynamic/templates/administration/settings/index.tt:448
+#: root/dynamic/templates/administration/settings/index.tt:466
 msgid "Prefix for guest passes"
 msgstr "Prefix för gästpass"
 
-#: root/dynamic/templates/administration/settings/index.tt:452
+#: root/dynamic/templates/administration/settings/index.tt:470
 msgid "Prefix for guest passes, defaults to 'guest' if none is specified."
-msgstr ""
-"Prefix för gästpass. Om det inte ändras kommer värdet bli \"guest\"."
+msgstr "Prefix för gästpass. Om det inte ändras kommer värdet bli \"guest\"."
 
-#: root/dynamic/templates/administration/index.tt:216
+#: root/dynamic/templates/administration/index.tt:223
 msgid "Print"
 msgstr "Skriv ut"
 
-#: root/dynamic/templates/administration/index.tt:1220
+#: root/dynamic/templates/administration/index.tt:1234
 msgid "Print job refreshed"
 msgstr "Utskriftskön har uppdaterats"
 
@@ -815,30 +829,30 @@ msgid "Print job retention"
 msgstr "Lagring av utskriftskö"
 
 #: root/dynamic/templates/administration/settings/index.tt:18
-#: root/dynamic/templates/administration/settings/index.tt:533
+#: root/dynamic/templates/administration/settings/index.tt:551
 msgid "Print management"
 msgstr "Utskriftsinställningar"
 
-#: root/dynamic/templates/administration/index.tt:200
+#: root/dynamic/templates/administration/index.tt:207
 msgid "Printer"
 msgstr "Skrivare"
 
-#: root/dynamic/templates/administration/settings/index.tt:536
+#: root/dynamic/templates/administration/settings/index.tt:554
 msgid "Printer configuration"
 msgstr "Skrivarinställningar"
 
-#: root/dynamic/templates/administration/index.tt:14
+#: root/dynamic/templates/administration/index.tt:13
 msgid "Prints"
 msgstr "Utskrifter"
 
-#: root/dynamic/templates/administration/settings/index.tt:558
+#: root/dynamic/templates/administration/settings/index.tt:576
 msgid "Public interface JavaScript"
 msgstr "Den offentliga delens javascipt"
 
-#: root/dynamic/templates/administration/index.tt:172
-#: root/dynamic/templates/administration/index.tt:224
-#: root/dynamic/templates/administration/index.tt:28
-#: root/dynamic/templates/administration/index.tt:98
+#: root/dynamic/templates/administration/index.tt:101
+#: root/dynamic/templates/administration/index.tt:179
+#: root/dynamic/templates/administration/index.tt:231
+#: root/dynamic/templates/administration/index.tt:27
 msgid "Refresh"
 msgstr "Uppdatera"
 
@@ -846,16 +860,16 @@ msgstr "Uppdatera"
 msgid "Renew the time allotment when it reaches zero"
 msgstr "Förnya tidsmängden när den når noll"
 
-#: root/dynamic/templates/administration/index.tt:1139
-#: root/dynamic/templates/public/index.tt:378
+#: root/dynamic/templates/administration/index.tt:1153
+#: root/dynamic/templates/public/index.tt:377
 msgid "Reservation canceled."
 msgstr "Reservationen har tagits bort."
 
-#: root/dynamic/templates/public/index.tt:257
+#: root/dynamic/templates/public/index.tt:256
 msgid "Reservation created."
 msgstr "Reservationen har gjorts."
 
-#: root/dynamic/templates/administration/index.tt:1047
+#: root/dynamic/templates/administration/index.tt:1061
 msgid "Reservation for user created."
 msgstr "Reservation gjord för användaren."
 
@@ -867,7 +881,7 @@ msgstr ""
 "Enbart reservationer. Användaren måste reservera en dator innan det går att "
 "logga in på den."
 
-#: root/dynamic/templates/public/index.tt:26
+#: root/dynamic/templates/public/index.tt:25
 msgid "Reservation status"
 msgstr "Reservationsstatus"
 
@@ -880,33 +894,33 @@ msgstr "Timeout för reservationer"
 msgid "Reservations"
 msgstr "Reservationer"
 
-#: root/dynamic/templates/administration/index.tt:143
+#: root/dynamic/templates/administration/index.tt:150
 msgid "Reserve"
 msgstr "Reservera"
 
-#: root/dynamic/templates/administration/index.tt:136
-#: root/dynamic/templates/public/index.tt:153
+#: root/dynamic/templates/administration/index.tt:143
+#: root/dynamic/templates/public/index.tt:152
 msgid "Reserved"
 msgstr "Reserverad"
 
-#: root/dynamic/templates/public/index.tt:150
+#: root/dynamic/templates/public/index.tt:149
 msgid "Reserved by"
 msgstr "Reserverad av"
 
-#: root/dynamic/templates/administration/index.tt:421
+#: root/dynamic/templates/administration/index.tt:431
 msgid "Roles"
 msgstr "Roller"
 
-#: root/dynamic/templates/administration/settings/index.tt:514
+#: root/dynamic/templates/administration/settings/index.tt:532
 msgid "SIP configuration"
 msgstr "SIP-konfiguration"
 
-#: root/dynamic/templates/administration/index.tt:132
-#: root/dynamic/templates/administration/index.tt:54
+#: root/dynamic/templates/administration/index.tt:139
+#: root/dynamic/templates/administration/index.tt:57
 msgid "Session minutes"
 msgstr "Minuter per datorpass"
 
-#: root/dynamic/templates/administration/index.tt:126
+#: root/dynamic/templates/administration/index.tt:129
 msgid "Session status"
 msgstr "Status på datorpass"
 
@@ -914,16 +928,16 @@ msgstr "Status på datorpass"
 msgid "Settings"
 msgstr "Inställningar"
 
-#: root/dynamic/templates/administration/settings/index.tt:602
+#: root/dynamic/templates/administration/settings/index.tt:620
 msgid "Settings not updated."
 msgstr "Inställningarna har inte uppdaterats."
 
-#: root/dynamic/templates/administration/settings/index.tt:599
+#: root/dynamic/templates/administration/settings/index.tt:617
 msgid "Settings updated."
 msgstr "Inställningarna har uppdaterats."
 
-#: root/dynamic/templates/administration/settings/index.tt:370
-#: root/dynamic/templates/administration/settings/index.tt:407
+#: root/dynamic/templates/administration/settings/index.tt:388
+#: root/dynamic/templates/administration/settings/index.tt:425
 msgid "Source URL"
 msgstr "Käll-URL"
 
@@ -940,10 +954,10 @@ msgstr ""
 "överstiger det här antalet dagar. Om det inte är satt kommer datan aldrig "
 "anonymiseras."
 
-#: root/dynamic/templates/administration/index.tt:199
-#: root/dynamic/templates/administration/index.tt:464
-#: root/dynamic/templates/administration/index.tt:55
-#: root/dynamic/templates/public/index.tt:24
+#: root/dynamic/templates/administration/index.tt:206
+#: root/dynamic/templates/administration/index.tt:474
+#: root/dynamic/templates/administration/index.tt:58
+#: root/dynamic/templates/public/index.tt:23
 msgid "Status"
 msgstr "Status"
 
@@ -951,7 +965,7 @@ msgstr "Status"
 msgid "Success:"
 msgstr "Lyckades:"
 
-#: root/dynamic/templates/administration/index.tt:485
+#: root/dynamic/templates/administration/index.tt:495
 msgid "Super administrator"
 msgstr "Superadministratör"
 
@@ -968,17 +982,17 @@ msgstr "Användaravtal"
 msgid "Terms of service text"
 msgstr "Användaravtalstext"
 
-#: root/dynamic/templates/administration/settings/index.tt:377
-#: root/dynamic/templates/administration/settings/index.tt:414
+#: root/dynamic/templates/administration/settings/index.tt:395
+#: root/dynamic/templates/administration/settings/index.tt:432
 msgid "The URL for the source image or image service."
 msgstr "UTL:en till bilden eller bildtjänsten."
 
-#: root/dynamic/templates/administration/settings/index.tt:399
-#: root/dynamic/templates/administration/settings/index.tt:436
+#: root/dynamic/templates/administration/settings/index.tt:417
+#: root/dynamic/templates/administration/settings/index.tt:454
 msgid "The height of the source image or image service in pixels."
 msgstr "Höjden av bilden eller bildtjänsten i pixlar."
 
-#: root/dynamic/templates/administration/settings/index.tt:463
+#: root/dynamic/templates/administration/settings/index.tt:481
 msgid "The number of passes to create per batch."
 msgstr "Antalet gästpass att skapa per grupp."
 
@@ -991,7 +1005,7 @@ msgstr ""
 "användaren inte loggat in inom det här tidsfönstret kommer reservationen tas "
 "bort."
 
-#: root/dynamic/templates/administration/settings/index.tt:482
+#: root/dynamic/templates/administration/settings/index.tt:500
 msgid ""
 "The text in this field will be prepended to the guest password, for example "
 "<i>Password:</i>. This field is displayed in monospace for ease of "
@@ -1001,7 +1015,7 @@ msgstr ""
 "<i>Password:</i>. Det här fältet visas i monospace för att göra det enklare "
 "att formatera."
 
-#: root/dynamic/templates/administration/settings/index.tt:472
+#: root/dynamic/templates/administration/settings/index.tt:490
 msgid ""
 "The text in this field will be prepended to the guest username, for example "
 "<i>Username:</i>. This field is displayed in monospace for ease of "
@@ -1011,29 +1025,29 @@ msgstr ""
 "exempel <i>Username:</i>. Det här fältet visas i monospace för att göra det "
 "enklare att formatera."
 
-#: root/dynamic/templates/administration/settings/index.tt:388
-#: root/dynamic/templates/administration/settings/index.tt:425
+#: root/dynamic/templates/administration/settings/index.tt:406
+#: root/dynamic/templates/administration/settings/index.tt:443
 msgid "The width of the source image or image service in pixels."
 msgstr "Bredden på bilden eller bildtjänsten i pixlar."
 
-#: root/dynamic/templates/administration/settings/index.tt:578
+#: root/dynamic/templates/administration/settings/index.tt:596
 msgid "These rules override the default time allowances"
 msgstr "De här reglerna kör över de vanliga inställningarna för tidsmängd"
 
-#: root/dynamic/templates/public/index.tt:224
-#: root/dynamic/templates/public/index.tt:277
+#: root/dynamic/templates/public/index.tt:223
+#: root/dynamic/templates/public/index.tt:276
 msgid "This client is already reserved."
 msgstr "Den här datorn är redan reserverad."
 
-#: root/dynamic/templates/public/index.tt:351
+#: root/dynamic/templates/public/index.tt:350
 msgid "This client is not currently reserved."
 msgstr "Den här datorn är inte reserverad."
 
-#: root/dynamic/templates/public/index.tt:268
+#: root/dynamic/templates/public/index.tt:267
 msgid "This kiosk is closed for the day."
 msgstr "Den här datorn har stängt för idag."
 
-#: root/dynamic/templates/public/index.tt:25
+#: root/dynamic/templates/public/index.tt:24
 msgid "Time remaining"
 msgstr "Tid kvar"
 
@@ -1046,63 +1060,63 @@ msgstr "Tidsinställningar"
 msgid "Timestamp"
 msgstr "Tidsstämpel"
 
-#: root/dynamic/templates/administration/history/statistics.tt:23
-#: root/dynamic/templates/administration/history/statistics.tt:26
+#: root/dynamic/templates/administration/history/statistics.tt:21
+#: root/dynamic/templates/administration/history/statistics.tt:24
 msgid "To"
 msgstr "Till"
 
-#: root/dynamic/templates/administration/settings/index.tt:367
+#: root/dynamic/templates/administration/settings/index.tt:385
 msgid "Top banner"
 msgstr "Övre banner"
 
-#: root/dynamic/templates/administration/history/statistics.tt:56
+#: root/dynamic/templates/administration/history/statistics.tt:54
 msgid "Total by date"
 msgstr "Total baserat på datum"
 
-#: root/dynamic/templates/administration/history/statistics.tt:77
+#: root/dynamic/templates/administration/history/statistics.tt:75
 msgid "Total by location"
 msgstr "Total baserat på plats"
 
-#: root/dynamic/templates/administration/index.tt:135
-#: root/dynamic/templates/administration/index.tt:57
-#: root/dynamic/templates/administration/index.tt:69
+#: root/dynamic/templates/administration/index.tt:142
+#: root/dynamic/templates/administration/index.tt:60
+#: root/dynamic/templates/administration/index.tt:72
 msgid "Troublemaker"
 msgstr "Problem"
 
-#: root/dynamic/templates/administration/index.tt:992
+#: root/dynamic/templates/administration/index.tt:1006
 msgid "Troublemaker status switched."
 msgstr "Problemstatus ändrad."
 
-#: root/dynamic/templates/administration/index.tt:198
+#: root/dynamic/templates/administration/index.tt:205
 msgid "Type"
 msgstr "Typ"
 
-#: root/dynamic/templates/administration/index.tt:1143
+#: root/dynamic/templates/administration/index.tt:1157
 msgid "Unable to cancel reservation."
 msgstr "Kunde inte ta bort reservationen."
 
-#: root/dynamic/templates/administration/index.tt:982
+#: root/dynamic/templates/administration/index.tt:996
 msgid "Unable to change password."
 msgstr "Kunde inte ändra lösenord."
 
-#: root/dynamic/templates/administration/index.tt:846
-#: root/dynamic/templates/administration/index.tt:869
+#: root/dynamic/templates/administration/index.tt:860
+#: root/dynamic/templates/administration/index.tt:883
 msgid "Unable to create guest user."
 msgstr "Kunde inte skapa gästanvändare."
 
-#: root/dynamic/templates/administration/index.tt:1113
+#: root/dynamic/templates/administration/index.tt:1127
 msgid "Unable to delete user."
 msgstr "Kunde inte ta bort användare."
 
-#: root/dynamic/templates/administration/index.tt:1127
+#: root/dynamic/templates/administration/index.tt:1141
 msgid "Unable to log user out."
 msgstr "Kunde inte logga ut användaren."
 
-#: root/dynamic/templates/administration/index.tt:1055
+#: root/dynamic/templates/administration/index.tt:1069
 msgid "Unable to modify reservation: Reason unknown."
 msgstr "Kunde inte ändra reservationen av en okänd anledning."
 
-#: root/dynamic/templates/administration/index.tt:1051
+#: root/dynamic/templates/administration/index.tt:1065
 msgid ""
 "Unable to modify reservation: User already has a reservation for a different "
 "client."
@@ -1110,24 +1124,24 @@ msgstr ""
 "Kunde inte ändra reservationen eftersom användaren redan har en reservation "
 "på en annan dator."
 
-#: root/dynamic/templates/administration/index.tt:1053
+#: root/dynamic/templates/administration/index.tt:1067
 msgid "Unable to modify reservation: User not found."
 msgstr "Kunde inte ändra reservationen eftersom användaren inte finns."
 
-#: root/dynamic/templates/administration/index.tt:995
+#: root/dynamic/templates/administration/index.tt:1009
 msgid "Unable to switch troublemaker status."
 msgstr "Kunde inte ändra problemstatus."
 
-#: root/dynamic/templates/administration/index.tt:1025
+#: root/dynamic/templates/administration/index.tt:1039
 msgid "Unable to update user's time."
 msgstr "Kunde unte uppdatera användarens tid."
 
-#: root/dynamic/templates/administration/index.tt:938
+#: root/dynamic/templates/administration/index.tt:952
 msgid "Unable to update user."
 msgstr "Kunde unte uppdatera anändaren."
 
 #: root/dynamic/templates/administration/hours/index.tt:80
-#: root/dynamic/templates/administration/settings/index.tt:586
+#: root/dynamic/templates/administration/settings/index.tt:604
 msgid "Update"
 msgstr "Uppdatera"
 
@@ -1135,11 +1149,11 @@ msgstr "Uppdatera"
 msgid "Update hours for all locations."
 msgstr "Uppdatera tiderna för alla platser."
 
-#: root/dynamic/templates/administration/index.tt:525
+#: root/dynamic/templates/administration/index.tt:535
 msgid "Update time"
 msgstr "Uppdateringstid"
 
-#: root/dynamic/templates/administration/index.tt:494
+#: root/dynamic/templates/administration/index.tt:504
 msgid "Update user"
 msgstr "Uppdatera användare"
 
@@ -1151,7 +1165,7 @@ msgstr ""
 "Användbart för att implementera <a href='https://eugdpr.org/' "
 "target='_blank'>GDPR</a>"
 
-#: root/dynamic/templates/administration/index.tt:204
+#: root/dynamic/templates/administration/index.tt:211
 msgid "User"
 msgstr "Användare"
 
@@ -1159,15 +1173,15 @@ msgstr "Användare"
 msgid "User categories"
 msgstr "Användarkategorier"
 
-#: root/dynamic/templates/administration/index.tt:821
+#: root/dynamic/templates/administration/index.tt:835
 msgid "User created."
 msgstr "Användare skapad."
 
-#: root/dynamic/templates/administration/index.tt:1109
+#: root/dynamic/templates/administration/index.tt:1123
 msgid "User deleted."
 msgstr "Användare borttagen."
 
-#: root/dynamic/templates/administration/index.tt:824
+#: root/dynamic/templates/administration/index.tt:838
 msgid "User not created."
 msgstr "Användare skapades inte."
 
@@ -1176,11 +1190,11 @@ msgstr "Användare skapades inte."
 msgid "User settings"
 msgstr "Användarinställningar"
 
-#: root/dynamic/templates/administration/index.tt:133
+#: root/dynamic/templates/administration/index.tt:140
 msgid "User status"
 msgstr "Användarstatus"
 
-#: root/dynamic/templates/administration/index.tt:935
+#: root/dynamic/templates/administration/index.tt:949
 msgid "User updated."
 msgstr "Användare uppdaterad."
 
@@ -1188,68 +1202,68 @@ msgstr "Användare uppdaterad."
 msgid "User's client is reserved"
 msgstr "Användarens dator är reserverad"
 
-#: root/dynamic/templates/administration/index.tt:1022
+#: root/dynamic/templates/administration/index.tt:1036
 msgid "User's time updated."
 msgstr "Användarens tid har uppdaterats."
 
 #: root/dynamic/templates/administration/history/index.tt:6
-#: root/dynamic/templates/administration/index.tt:127
-#: root/dynamic/templates/administration/index.tt:267
-#: root/dynamic/templates/administration/index.tt:268
-#: root/dynamic/templates/administration/index.tt:344
-#: root/dynamic/templates/administration/index.tt:430
-#: root/dynamic/templates/administration/index.tt:49
-#: root/dynamic/templates/administration/index.tt:545
+#: root/dynamic/templates/administration/index.tt:130
+#: root/dynamic/templates/administration/index.tt:274
+#: root/dynamic/templates/administration/index.tt:275
+#: root/dynamic/templates/administration/index.tt:354
+#: root/dynamic/templates/administration/index.tt:440
+#: root/dynamic/templates/administration/index.tt:48
+#: root/dynamic/templates/administration/index.tt:555
 #: root/dynamic/templates/login.tt:23 root/dynamic/templates/login.tt:27
-#: root/dynamic/templates/public/index.tt:58
+#: root/dynamic/templates/public/index.tt:57
 msgid "Username"
 msgstr "Användarnamn"
 
-#: root/dynamic/templates/public/index.tt:261
+#: root/dynamic/templates/public/index.tt:260
 msgid "Username & password do not match."
 msgstr "Användarnamn och lösenord stämmer inte överens."
 
-#: root/dynamic/templates/administration/index.tt:274
+#: root/dynamic/templates/administration/index.tt:281
 msgid "Username already used"
 msgstr "Användarnamnet är upptaget"
 
-#: root/dynamic/templates/administration/index.tt:549
+#: root/dynamic/templates/administration/index.tt:559
 msgid "Username is invalid"
 msgstr "Användarnamnet stämmer inte"
 
-#: root/dynamic/templates/public/index.tt:61
+#: root/dynamic/templates/public/index.tt:60
 msgid "Username is required"
 msgstr "Användarnamn krävs"
 
-#: root/dynamic/templates/administration/index.tt:271
+#: root/dynamic/templates/administration/index.tt:278
 msgid "Username is unique"
 msgstr "Användarnamnet är unikt"
 
-#: root/dynamic/templates/administration/settings/index.tt:467
+#: root/dynamic/templates/administration/settings/index.tt:485
 msgid "Username label"
 msgstr "Användarnamnsfält"
 
-#: root/dynamic/templates/administration/index.tt:432
+#: root/dynamic/templates/administration/index.tt:442
 msgid "Username may not be edited."
 msgstr "Använarnamnet kan inte ändras."
 
-#: root/dynamic/templates/administration/index.tt:269
+#: root/dynamic/templates/administration/index.tt:276
 msgid "Username must be unique."
 msgstr "Användarnamnet måste vara unikt."
 
-#: root/dynamic/templates/administration/index.tt:547
+#: root/dynamic/templates/administration/index.tt:557
 msgid "Username of user to make reservation for."
 msgstr "Användare att göra en reservation för."
 
-#: root/dynamic/templates/administration/index.tt:7
+#: root/dynamic/templates/administration/index.tt:6
 msgid "Users"
 msgstr "Användare"
 
-#: root/dynamic/templates/administration/index.tt:240
+#: root/dynamic/templates/administration/index.tt:247
 msgid "View"
 msgstr "Se"
 
-#: root/dynamic/templates/administration/index.tt:392
+#: root/dynamic/templates/administration/index.tt:402
 msgid "View & print guest passes"
 msgstr "Se och skriv ut gästpass"
 
@@ -1282,101 +1296,105 @@ msgstr ""
 msgid "When extending time"
 msgstr "När tiden förlängs"
 
-#: root/dynamic/templates/administration/settings/index.tt:381
-#: root/dynamic/templates/administration/settings/index.tt:418
+#: root/dynamic/templates/administration/settings/index.tt:399
+#: root/dynamic/templates/administration/settings/index.tt:436
 msgid "Width"
 msgstr "Bredd"
 
-#: root/dynamic/templates/public/index.tt:325
+#: root/dynamic/templates/public/index.tt:324
 msgid "You are not of the appropriate age to use this client."
 msgstr "Du är inte tillräckigt gammal för att använda den här datorn."
 
-#: root/dynamic/templates/public/index.tt:274
+#: root/dynamic/templates/public/index.tt:273
 msgid "You have already reserved a client."
 msgstr "Du har redan reserverat en dator."
 
-#: root/dynamic/templates/public/index.tt:271
+#: root/dynamic/templates/public/index.tt:270
 msgid "You have already reserved this client."
 msgstr "Du har redan reserverat den här datorn."
 
-#: root/dynamic/templates/public/index.tt:319
+#: root/dynamic/templates/public/index.tt:318
 msgid "You have an overdue item recall."
 msgstr "Du har lånat något som är försenat."
 
-#: root/dynamic/templates/public/index.tt:322
+#: root/dynamic/templates/public/index.tt:321
 msgid "You have been billed for too many items."
 msgstr "Du har fått för många räkningar."
 
-#: root/dynamic/templates/public/index.tt:307
+#: root/dynamic/templates/public/index.tt:306
 msgid "You have claimed returned for too many items."
 msgstr "Du har lånat för många saker som tappats bort."
 
-#: root/dynamic/templates/public/index.tt:280
+#: root/dynamic/templates/public/index.tt:279
 msgid "You have excessive oustanding fees."
 msgstr "Du har för höga avgifter."
 
-#: root/dynamic/templates/public/index.tt:316
+#: root/dynamic/templates/public/index.tt:315
 msgid "You have excessive outstanding fees."
 msgstr "Du har för höga avgifter."
 
-#: root/dynamic/templates/public/index.tt:313
+#: root/dynamic/templates/public/index.tt:312
 msgid "You have excessive outstanding fines."
 msgstr "Du har för höga avgifter."
 
-#: root/dynamic/templates/public/index.tt:310
+#: root/dynamic/templates/public/index.tt:309
 msgid "You have lost too many items."
 msgstr "Du har tappat bort för många saker."
 
-#: root/dynamic/templates/public/index.tt:265
+#: root/dynamic/templates/public/index.tt:264
 msgid "You have no time remaining."
 msgstr "Du har slut på tid."
 
-#: root/dynamic/templates/public/index.tt:304
+#: root/dynamic/templates/public/index.tt:303
 msgid "You have renewed too many items."
 msgstr "Du har lånat om för många lån."
 
-#: root/dynamic/templates/public/index.tt:298
+#: root/dynamic/templates/public/index.tt:297
 msgid "You have too many items checked out."
 msgstr "Du har lånat för många lån."
 
-#: root/dynamic/templates/public/index.tt:301
+#: root/dynamic/templates/public/index.tt:300
 msgid "You have too many overdue items."
 msgstr "Du har för många försenade lån."
 
-#: root/dynamic/templates/public/index.tt:283
+#: root/dynamic/templates/public/index.tt:282
 msgid "Your checkout privileges have been denied."
 msgstr "Du får inte låna längre."
 
-#: root/dynamic/templates/public/index.tt:292
+#: root/dynamic/templates/public/index.tt:291
 msgid "Your hold privileges have been denied."
 msgstr "Du får inte reservera längre."
 
-#: root/dynamic/templates/public/index.tt:295
+#: root/dynamic/templates/public/index.tt:294
 msgid "Your library card has been reported lost or stolen."
 msgstr "Ditt bibliotekskort har anmälts som borttappat eller stulet."
 
-#: root/dynamic/templates/public/index.tt:289
+#: root/dynamic/templates/public/index.tt:288
 msgid "Your recall privileges have been denied."
 msgstr "Du kan inte återkalla längre."
 
-#: root/dynamic/templates/public/index.tt:286
+#: root/dynamic/templates/public/index.tt:285
 msgid "Your renewal privileges have been denied."
 msgstr "Du kan inte låna om längre."
 
-#: root/dynamic/templates/public/index.tt:382
+#: root/dynamic/templates/public/index.tt:381
 msgid "Your reservation cancelation failed for an unknown reason."
 msgstr "Du kunde inte avbryta din reservation av en okänd anledning."
+
+#: root/dynamic/templates/administration/hours/index.tt:0
+#, fuzzy
+msgid "d"
+msgstr "$d"
 
 #: root/dynamic/templates/administration/hours/index.tt:140
 #: root/dynamic/templates/administration/hours/index.tt:99
 msgid "for"
 msgstr "för"
 
-# Strings not autogenerated by xgettext
-# Language menu
-#: root/dynamic/includes/language_menu.tt:8
-msgid "lang.$lang"
-msgstr "lang.$lang"
+#: root/dynamic/includes/breadcrumbs.tt:5
+#: root/dynamic/includes/breadcrumbs.tt:9
+msgid "item.label"
+msgstr "item.label"
 
 # Strings not autogenerated by xgettext
 # Language menu
@@ -1418,8 +1436,10 @@ msgstr "Öppettider"
 msgid "Login"
 msgstr "Inloggning"
 
-#~ msgid "('lang.' _ lang)"
-#~ msgstr "('lang.' _ lang)"
+# Strings not autogenerated by xgettext
+# Language menu
+#~ msgid "lang.$lang"
+#~ msgstr "lang.$lang"
 
 #~ msgid "Amount of time a registered user is given per session."
 #~ msgstr "Mängden tid gästanvändaren får per datorpass."
@@ -1432,9 +1452,6 @@ msgstr "Inloggning"
 
 #~ msgid "URL"
 #~ msgstr "URL"
-
-#~ msgid "item.label"
-#~ msgstr "item.label"
 
 #~ msgid "The URL for the source image or image service"
 #~ msgstr "URL:en till bilden eller bildtjänsten"

--- a/root/dynamic/templates/administration/index.tt
+++ b/root/dynamic/templates/administration/index.tt
@@ -46,9 +46,13 @@
         <table id="user-table" cellpadding="0" cellspacing="0" border="0" class="table table-striped table-bordered">
             <thead>
                 <th>[% c.loc("Username") %]</th>
+                [% IF ShowFirstLastNames %]
                 <th>[% c.loc("Lastname") %] </th>
                 <th>[% c.loc("Firstname") %] </th>
+                [% END %]
+                [% IF UserCategories %]
                 <th>[% c.loc("Category") %]</th>
+                [% END %]
                 <th>[% c.loc("Daily minutes") %]</th>
                 <th>[% c.loc("Session minutes") %]</th>
                 <th>[% c.loc("Status") %]</th>
@@ -124,9 +128,13 @@
                 <th>[% c.loc("Location") %]</th>
                 <th>[% c.loc("Session status") %]</th>
                 <th>[% c.loc("Username") %]</th>
+                [% IF ShowFirstLastNames %]
                 <th>[% c.loc("Lastname") %] </th>
                 <th>[% c.loc("Firstname") %] </th>
+                [% END %]
+                [% IF UserCategories %]
                 <th>[% c.loc("Category") %]</th>
+                [% END %]
                 <th>[% c.loc("Daily minutes") %]</th>
                 <th>[% c.loc("Session minutes") %]</th>
                 <th>[% c.loc("User status") %]</th>
@@ -274,6 +282,7 @@
                 </div>
             </div>
 
+            [% IF ShowFirstLastNames %]
             <div class="form-group">
                 <label for="new-user-modal-form-name">[% c.loc("Name") %]</label>
                 <div class="row">
@@ -285,7 +294,8 @@
                   </div>
                 </div>
             </div>
-
+            [% END %]
+            [% IF UserCategories %]
             <div class="form-group">
                 <label for="new-user-modal-form-category">[% c.loc("Category") %]</label>
                 <select class="form-control" id="new-user-modal-form-category" name="category">
@@ -295,6 +305,7 @@
                     [% END %]
                 </select>
             </div>
+            [% END %]
 
             <div class="form-group">
                 <label for="new-user-modal-form-password">[% c.loc("Password") %]</label>

--- a/root/dynamic/templates/administration/settings/index.tt
+++ b/root/dynamic/templates/administration/settings/index.tt
@@ -347,7 +347,7 @@
                             <textarea class="form-control" id="UserCategories" name="UserCategories" rows="10">[% UserCategories %]</textarea>
                         </div>
                         <small class="form-text text-muted">[% c.loc("Add your list of user categories here as a list in YAML syntax.") %]</small>
-                        <small class="form-text text-muted">Example:
+                        <small class="form-text text-muted">[% c.loc("Example:") %]
                             <pre>
 ---
 - 'Category 1'
@@ -356,6 +356,24 @@
                             </pre>
                         </small>
                     </div>
+                    <div class="form-group">
+                        <input  id="ShowFirstLastNames" name="ShowFirstLastNames" type="checkbox" [% IF ShowFirstLastNames %]checked="checked"[% END %]>
+                        <label for="ShowFirstLastNamesCheckbox">[% c.loc("Display first and last names") %]</label>
+                        <small class="form-text text-muted">[% c.loc("If not checked, the possibility to enter users' first and last name will disappear.") %]</small>
+                    </div>
+                    <script type="text/javascript">
+                        $(document).ready(function() {
+                            $("#ShowFirstLastNamesCheckbox").attr('checked', Boolean( [% ShowFirstLastNames %] ) );
+
+                            $("#ShowFirstLastNamesCheckbox").change( function() {
+                                if ( $(this).attr('checked') == 'checked') {
+                                    $("#ShowFirstLastNames").val( 1 );
+                                } else {
+                                    $("#ShowFirstLastNames").val( 0 );
+                                }
+                            });
+                        });
+                    </script>
                 </fieldset>
             </div>
 


### PR DESCRIPTION
This automatically hides categories when there are no categories entered in the settings - both in DataTables and in the create new user form.

It also includes a new user setting (default to true) that enables or disables the usage of first and last names. Just as with categories, it hides them both in DataTables and in the create new user form.