### PR TITLE
Enforcing specific version of DBIx::Class::EncodedColumn

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -27,7 +27,7 @@ requires 'CatalystX::Script::Server::Starman';
 requires 'Config::General';
 requires 'DBD::mysql';
 requires 'DBIx::Class::Cursor::Cached';
-requires 'DBIx::Class::EncodedColumn';
+requires 'DBIx::Class::EncodedColumn', '== 0.00016';
 requires 'DBIx::Class::InflateColumn::Serializer';
 requires 'DBIx::Class::InflateColumn::Serializer::JSON';
 requires 'DBIx::Class::Numeric';


### PR DESCRIPTION
Something is wrong with the new version, making it not installing. Enforcing the previous version.