### PR TITLE
Issue when using advanced rules for allowing time

### DIFF
--- a/lib/Catalyst/Plugin/LibkiSetting.pm
+++ b/lib/Catalyst/Plugin/LibkiSetting.pm
@@ -313,7 +313,18 @@ sub check_login {
     # 2. Get the available minutes
     if(!$result{'error'}) {
         my $allotment = $user->minutes_allotment;
-        my $allowance = $user->is_guest() eq 'Yes'
+        # Get advanced rule if there is one
+        my $allowance = $c->get_rule(
+                             {
+                                 rule            => $user->is_guest eq 'Yes' ? 'guest_session' : 'session',
+                                 client_location => $client->location,
+                                 client_type     => $client->type,
+                                 client_name     => $client->name,
+                                 client_type     => $client->type,
+                                 user_category   => $user->category,
+                             }
+                         );
+        $allowance //= $user->is_guest() eq 'Yes'
               ? $c->setting('DefaultGuestSessionTimeAllowance')
               : $c->setting('DefaultSessionTimeAllowance');
 

--- a/lib/Libki/SIP.pm
+++ b/lib/Libki/SIP.pm
@@ -206,8 +206,6 @@ sub authenticate_via_sip {
         $user->update();
     }
     else {          ## User authenticated and does not exits in Libki
-        my $minutes =
-          $c->model('DB::Setting')->find({ instance => $instance, name => 'DefaultTimeAllowance' })->value;
         my($lastname, $firstname) = split($c->config->{SIP}->{pattern_personal_name}, $sip_fields->{AE});
         $lastname=~ s/^\s+//;
         $firstname =~ s/^\s+//;
@@ -218,7 +216,7 @@ sub authenticate_via_sip {
                 instance          => $instance,
                 username          => $username,
                 password          => $password,
-                minutes_allotment => $minutes,
+                minutes_allotment => undef,
                 status            => 'enabled',
                 birthdate         => $birthdate,
                 lastname          => $lastname,

--- a/lib/Libki/Schema/DB/Result/User.pm
+++ b/lib/Libki/Schema/DB/Result/User.pm
@@ -366,32 +366,6 @@ sub has_role {
     return any( map { $_->role } $self->roles ) eq $role;
 }
 
-=head2 insert
-
-Wrap DBIx::Class::Row::insert to handle daily vs session minutes
-
-=cut
-
-sub insert {
-    my ( $self, @args ) = @_;
-
-    my $schema = $self->result_source->schema;
-
-    my $is_guest = $self->is_guest || 'No';
-
-    my $default_time_allowance_setting_name = $is_guest eq 'Yes' ? 'DefaultGuestTimeAllowance' : 'DefaultTimeAllowance';
-
-    unless ( $self->minutes_allotment ) {
-        my $default_time_allowance_setting = $schema->resultset('Setting')->find({ instance => $self->instance, name => $default_time_allowance_setting_name });
-        my $default_time_allowance = $default_time_allowance_setting ? $default_time_allowance_setting->value : 0;
-        $self->minutes_allotment( $default_time_allowance );
-    }
-
-    $self->next::method(@args);
-
-    return $self;
-}
-
 =head2 age
 
 Returns the age of the patron.


### PR DESCRIPTION
     for reproduce without patch:
       Choose a user SIP (User1) not exist in Libki and  his category for example is A.
       My advanced rules is:
         -
           criteria:
             user_category:
               - A
           rules:
             session: 120
             daily: 240
             guest_session: 60
             guest_daily: 120

       My Time settings:
         Default time allowance per day : 120
         Default time allowance per session: 60
         Default guest time allowance per day: 120
         Default guest time allowance per session: 60
       When User1 connect to Libki, the time allowed
       is 60 minutes (Default time allowance per session),
       it's not correct, normaly the time allowed
       is 120 minutes( session defined in advanced rules).
       When user exist in Libki, libki_nightly set minutes_allotment to undef
       and when user connect to libki, minutes_allotment get value in
       advanced rules, but when call sub check_login, the value of allowance is not use
       advanced rules.
    with patch:
       using the same settings( advanced rules and Time settings)
         - delete User1 in Libki
         When User1 connect to Libki, the time allowed is 120 minutes
         - logout User1
         - run libki_nigthly
         - when login with User1, the time allowed is 120 minutes.