### PR TITLE
New feature - Keeping track of offline clients

### DIFF
--- a/installer/versions/4/0.2_add-field-status-for-clients.sql
+++ b/installer/versions/4/0.2_add-field-status-for-clients.sql
@@ -1,0 +1,1 @@
+ALTER TABLE clients ADD COLUMN `status` varchar(191) DEFAULT 'online' AFTER `location`;

--- a/lib/Libki/Controller/API/Public/Datatables.pm
+++ b/lib/Libki/Controller/API/Public/Datatables.pm
@@ -31,7 +31,7 @@ sub clients : Local Args(0) {
     my @columns = qw/ me.name me.location me.type session.status session.minutes /;
 
     # Set up filters
-    my $filter = { instance => $instance};
+    my $filter = { instance => $instance, status => "online" };
 
     my $search_term = $c->request->param("sSearch");
     if ($search_term) {

--- a/lib/Libki/Controller/Administration/API/Client.pm
+++ b/lib/Libki/Controller/Administration/API/Client.pm
@@ -135,6 +135,50 @@ sub reservation : Local : Args(1) {
     $c->forward( $c->view('JSON') );
 }
 
+=head2 toggle_status
+
+ Switch client status.
+
+=cut
+
+sub toggle_status : Local : Args(1) {
+    my ( $self, $c, $id ) = @_;
+    my $instance = $c->instance;
+
+    my $success = 0;
+    my $client = $c->model('DB::Client')->find({ instance => $instance, id => $id });
+    if($client) {
+        my $status = ( $client->status eq 'suspension' ) ? 'offline' : 'suspension';
+        $client->set_column( 'status', $status );
+
+        if ( $client->update() ) {
+            $success = 1;
+        }
+    }
+    $c->stash( 'success' => $success );
+    $c->forward( $c->view('JSON') );
+}
+
+=head2 delete_client
+
+ Delete client.
+
+=cut
+
+sub delete_client : Local : Args(1) {
+    my ( $self, $c, $id ) = @_;
+    my $instance = $c->instance;
+
+    my $success = 0;
+    my $client = $c->model('DB::Client')->find({ instance => $instance, id => $id });
+    if($client) {
+        $c->model('DB::Reservation')->search({ client_id => $id })->delete();
+        $success = 1 if ( $client->delete() );
+    }
+    $c->stash( 'success' => $success );
+    $c->forward( $c->view('JSON') );
+}
+
 =head1 AUTHOR
 
 Kyle M Hall <kyle@kylehall.info>

--- a/lib/Libki/Controller/Administration/API/DataTables.pm
+++ b/lib/Libki/Controller/Administration/API/DataTables.pm
@@ -147,7 +147,7 @@ sub clients : Local Args(0) {
 
     # We need to map the table columns to field names for ordering
     my @columns =
-      qw/ me.name me.location me.type session.status user.username user.lastname user.firstname user.category user.minutes_allotment session.minutes user.status user.notes user.is_troublemaker/;
+      qw/ me.name me.location me.type session.status user.username user.lastname user.firstname user.category user.minutes_allotment session.minutes user.status user.notes user.is_troublemaker me.status/;
 
     if ($userCategories eq '') {
         splice @columns, 6, 1;
@@ -165,6 +165,7 @@ sub clients : Local Args(0) {
         $filter->{-or} = [
             'me.name'       => { 'like', "%$search_term%" },
             'me.location'   => { 'like', "%$search_term%" },
+            'me.status'     => { 'like', "%$search_term%" },
             'me.type'       => { 'like', "%$search_term%" },
             'user.username' => { 'like', "%$search_term%" },
         ];
@@ -238,6 +239,7 @@ sub clients : Local Args(0) {
             defined( $c->session ) ? $c->session->user->is_troublemaker : undef,
             defined( $reservation ) ? $reservation->user->username : undef,
             defined( $reservation ) ? $begin : undef,
+            $c->status,
         );
 
         if ($userCategories eq '') {

--- a/lib/Libki/Schema/DB/Result/Client.pm
+++ b/lib/Libki/Schema/DB/Result/Client.pm
@@ -74,6 +74,13 @@ __PACKAGE__->table("clients");
   is_nullable: 1
   size: 191
 
+=head2 status
+
+  data_type: 'varchar'
+  default_value: 'online'
+  is_nullable: 0
+  size: 191
+
 =head2 type
 
   data_type: 'varchar'
@@ -97,6 +104,8 @@ __PACKAGE__->add_columns(
   { data_type => "varchar", is_nullable => 0, size => 191 },
   "location",
   { data_type => "varchar", is_nullable => 1, size => 191 },
+  "status",
+  { data_type => "varchar", default_value => "online", is_nullable => 0, size => 191 },
   "type",
   { data_type => "varchar", is_nullable => 1, size => 191 },
   "last_registered",

--- a/root/dynamic/templates/administration/index.tt
+++ b/root/dynamic/templates/administration/index.tt
@@ -142,6 +142,7 @@
                 <th>[% c.loc("Troublemaker") %]</th>
                 <th>[% c.loc("Reserved") %]</th>
                 <th>[% c.loc("From") %]</th>
+                <th>[% c.loc("Status") %]</th>
             </thead>
         </table> 
 
@@ -153,6 +154,8 @@
                 <button id="client-table-row-toolbar-cancel" class="btn btn-secondary" onclick="LibkiShowCancelClientTab( window.selected_id )"><i class="fas fa-times"></i> [% c.loc("Cancel reservation") %]</button>
                 [% END %]
                 <button id="client-table-row-toolbar-logout" class="btn btn-danger" onclick="LibkiLogOutClient( window.selected_id )"><i class="fas fa-sign-out-alt"></i> [% c.loc("Log out") %]</button>
+                <button id="client-table-row-toolbar-status" class="btn btn-secondary"><i class="fas fa-tag"></i> [% c.loc("Switch suspension") %]</button>
+                <button id="client-table-row-toolbar-delete" class="btn btn-warning" onclick="LibkiDeleteClient( window.selected_id )"><i class="fas fa-times"></i> [% c.loc("Delete") %]</button>
             </div>
         </div>
   </div>
@@ -1273,6 +1276,18 @@ $(document).ready(function() {
         }
     });
 
+    /* Toggle client status */
+    $('#client-table-row-toolbar-status').click(function(){
+        $.getJSON('[% c.uri_for("api/client/toggle_status") %]/' + window.selected_id, function(data) {
+            if ( parseInt( data.success ) ) {
+                    DisplayMessage( "success", "[% c.loc("Client status switched.") %]" );
+                    $("#client-table").dataTable().fnDraw(true);
+            } else {
+                    DisplayMessage( "error", "[% c.loc("Unable to switch client status.") %]" );
+            }
+        });
+    });
+
     /* Make reservation */
     $('#make-reservation-modal-form-submit').click(function(){
         let username = $('#make-reservation-modal-form-username').val();
@@ -1389,6 +1404,21 @@ function LibkiDeleteUser( id ) {
              } else {
                  DisplayMessage( "error", "[% c.loc("Unable to delete user.") %]" );
              }
+         }
+    });
+  }
+}
+
+function LibkiDeleteClient( id ) {
+  if ( confirm("[% c.loc("Once deleted, all the reservations of this client will be removed at the same time.") %]") ) {
+    $.getJSON( '[% c.uri_for('/administration/api/client/delete_client') %]' + '/' + id, function( data ) {
+         if ( data.success ) {
+             DisplayMessage( "success", "[% c.loc("Client deleted.") %]" );
+             // Refresh the table to remove the deleted row
+             $("#client-table").dataTable().fnDraw(true);
+             $("#reservation-table").dataTable().fnDraw(true);
+         } else {
+             DisplayMessage( "error", "[% c.loc("Unable to delete client.") %]" );
          }
     });
   }

--- a/script/cronjobs/libki.pl
+++ b/script/cronjobs/libki.pl
@@ -53,7 +53,7 @@ foreach my $s (@$sessions_to_delete) {
             username    => $s->{username},
             client_name => $s->{name},
             action      => 'SESSION_DELETED',
-            when        => $when,
+            created_on  => $when,
         }
     );
 }

--- a/script/cronjobs/libki.pl
+++ b/script/cronjobs/libki.pl
@@ -209,8 +209,8 @@ foreach my $pct (@post_crash_timeouts) {
     );
 
     $c->model('DB::Client')
-      ->search( { instance => $pct->instance, last_registered => { '<', $timestamp } } )
-      ->delete();
+      ->search( { instance => $pct->instance, last_registered => { '<', $timestamp }, status => 'online' } )
+      ->update( { status => 'offline' } );
 }
 
 ## Clear out any expired reservations


### PR DESCRIPTION
1. client status: online/offline/suspension
2. In the public interface, the client doesn't show up when its status is offline or suspension.
3. In the admin interface, admin user can remove the client from the list
4. In the admin interface, admin user can  switch the status offline/suspension. (no modal, just switch)
5. Cronjob libki.pl will no longer delete the offline clients, but will mark them as offline instead.
6. New field status for table clients.

The pullrequest also includes a bug fix commit.