### PR TITLE
Lets an admin unlock a client from the interface

### DIFF
--- a/lib/Libki/Controller/API/Client/v1_0.pm
+++ b/lib/Libki/Controller/API/Client/v1_0.pm
@@ -70,6 +70,15 @@ sub index : Path : Args(0) {
             }
         );
         my $client_s = $c->model('DB::Client')->find( { name => $node_name } );
+
+        if ($client_s->status eq "unlock") {
+            $c->stash(
+                unlock   => 1,
+                minutes  => $client_s->session->minutes,
+                username => $client_s->session->user->username,
+            );
+        }
+
         $client_s->update( { status => 'online' } ) if ( $client_s->status ne 'suspension' );
         $log->debug( "Client Registered: " . $client->name() );
 

--- a/root/dynamic/templates/administration/index.tt
+++ b/root/dynamic/templates/administration/index.tt
@@ -153,6 +153,7 @@
                 <button id="client-table-row-toolbar-reserve" class="btn btn-primary" onclick="LibkiToggleReservation( window.selected_id )"><i class="fas fa-tag"></i> [% c.loc("Reserve") %]</button>
                 <button id="client-table-row-toolbar-cancel" class="btn btn-secondary" onclick="LibkiShowCancelClientTab( window.selected_id )"><i class="fas fa-times"></i> [% c.loc("Cancel reservation") %]</button>
                 [% END %]
+                <button id="client-table-row-toolbar-unlock" class="btn btn-primary" onclick="LibkiUnlockClient( window.selected_id )"><i class="fas fa-unlock"></i> [% c.loc("Unlock") %]</button>
                 <button id="client-table-row-toolbar-logout" class="btn btn-danger" onclick="LibkiLogOutClient( window.selected_id )"><i class="fas fa-sign-out-alt"></i> [% c.loc("Log out") %]</button>
                 <button id="client-table-row-toolbar-status" class="btn btn-secondary"><i class="fas fa-tag"></i> [% c.loc("Switch suspension") %]</button>
                 <button id="client-table-row-toolbar-delete" class="btn btn-warning" onclick="LibkiDeleteClient( window.selected_id )"><i class="fas fa-times"></i> [% c.loc("Delete") %]</button>
@@ -1433,6 +1434,19 @@ function LibkiLogOutClient( id ) {
              $("#client-table").dataTable().fnDraw(true);
          } else {
              DisplayMessage( "error", "[% c.loc("Unable to log user out.") %]" );
+         }
+     });
+  }
+}
+
+function LibkiUnlockClient( id ) {
+  if ( confirm("[% c.loc("Are you sure you want to unlock this client?") %]") ) {
+    $.getJSON( '[% c.uri_for('/administration/api/client/unlock') %]' + '/' + id, function(data) {
+         if ( data.success ) {
+             DisplayMessage( "success", "[% c.loc("Client unlocked.") %]" );
+             $("#client-table").dataTable().fnDraw(true);
+         } else {
+             DisplayMessage( "error", "[% c.loc("Unable to unlock client.") %]" );
          }
      });
   }


### PR DESCRIPTION
This feature must be tested with the corresponding patch for the client.

A new unlock button in the client table makes it possible for an admin user to remotely unlock a client. A session will be started on the client for a guest user named using the guest prefix and the client name. When the client receives the signal (during the register_node action), it will unlock.