### PR TITLE
Add ability to calculate daily minutes independently by location

### DIFF
--- a/installer/versions/4/0.4_create-minutes-allotment-table.sql
+++ b/installer/versions/4/0.4_create-minutes-allotment-table.sql
@@ -1,0 +1,24 @@
+--
+-- Table structure for table `allotments`
+--
+
+CREATE TABLE `allotments` (
+  `instance` varchar(32) NOT NULL DEFAULT '',
+  `user_id` int(11) NOT NULL,
+  `location` varchar(191),
+  `minutes` int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (`user_id`, `location`)
+) ENGINE=InnoDB;
+
+-- Constraints for table 'allotments'
+--
+
+ALTER TABLE `allotments`
+    ADD CONSTRAINT `allotments_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+--
+-- Drop superfluous column from 'users'
+--
+
+ALTER TABLE `users`
+    DROP COLUMN `minutes_allotment`;

--- a/lib/Libki/Controller/Administration/Settings.pm
+++ b/lib/Libki/Controller/Administration/Settings.pm
@@ -64,7 +64,7 @@ sub update :Local :Args(0) {
     }
 
     # Checkboxes need to be converted to boolean values 
-    foreach my $pref ( qw( ReservationShowUsername EnableClientSessionLocking ) ) {
+    foreach my $pref ( qw( ReservationShowUsername EnableClientSessionLocking TimeAllowanceByLocation ) ) {
         $c->model('DB::Setting')->update_or_create(
             {
                 instance => $instance,

--- a/lib/Libki/LDAP.pm
+++ b/lib/Libki/LDAP.pm
@@ -47,15 +47,11 @@ sub authenticate_via_ldap {
         $user->update();
     }
     else {          ## User authenticated and does not exist in Libki
-        my $minutes =
-          $c->model('DB::Setting')->find({ instance => $instance, name => 'DefaultTimeAllowance' })->value;
-
         $user = $c->model('DB::User')->create(
             {
                 instance          => $instance,
                 username          => $username,
                 password          => $password,
-                minutes_allotment => $minutes,
                 status            => 'enabled',
                 creation_source   => 'LDAP',
             }

--- a/lib/Libki/SIP.pm
+++ b/lib/Libki/SIP.pm
@@ -223,7 +223,6 @@ sub authenticate_via_sip {
                 instance          => $instance,
                 username          => $username,
                 password          => $password,
-                minutes_allotment => undef,
                 status            => 'enabled',
                 birthdate         => $birthdate,
                 lastname          => $lastname,

--- a/lib/Libki/Schema/DB/Result/Allotment.pm
+++ b/lib/Libki/Schema/DB/Result/Allotment.pm
@@ -1,0 +1,128 @@
+use utf8;
+package Libki::Schema::DB::Result::Allotment;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Libki::Schema::DB::Result::Allotment
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose;
+use MooseX::NonMoose;
+use MooseX::MarkAsMethods autoclean => 1;
+extends 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=item * L<DBIx::Class::TimeStamp>
+
+=item * L<DBIx::Class::EncodedColumn>
+
+=item * L<DBIx::Class::Numeric>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components(
+  "InflateColumn::DateTime",
+  "TimeStamp",
+  "EncodedColumn",
+  "Numeric",
+);
+
+=head1 TABLE: C<allotments>
+
+=cut
+
+__PACKAGE__->table("allotments");
+
+=head1 ACCESSORS
+
+=head2 instance
+
+  data_type: 'varchar'
+  default_value: (empty string)
+  is_nullable: 0
+  size: 32
+
+=head2 user_id
+
+  data_type: 'integer'
+  is_foreign_key: 1
+  is_nullable: 0
+
+=head2 location
+
+  data_type: 'varchar'
+  is_nullable: 0
+  size: 191
+
+=head2 minutes
+
+  data_type: 'integer'
+  default_value: 0
+  is_nullable: 0
+
+=cut
+
+__PACKAGE__->add_columns(
+  "instance",
+  { data_type => "varchar", default_value => "", is_nullable => 0, size => 32 },
+  "user_id",
+  { data_type => "integer", is_foreign_key => 1, is_nullable => 0 },
+  "location",
+  { data_type => "varchar", is_nullable => 0, size => 191 },
+  "minutes",
+  { data_type => "integer", default_value => 0, is_nullable => 0 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</user_id>
+
+=item * L</location>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("user_id", "location");
+
+=head1 RELATIONS
+
+=head2 user
+
+Type: belongs_to
+
+Related object: L<Libki::Schema::DB::Result::User>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "user",
+  "Libki::Schema::DB::Result::User",
+  { id => "user_id" },
+  { is_deferrable => 1, on_delete => "CASCADE", on_update => "CASCADE" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07048 @ 2020-06-04 03:13:52
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:pX5yuaz3N7W2MGb9LPuyDQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/Libki/Users.pm
+++ b/lib/Libki/Users.pm
@@ -140,18 +140,27 @@ sub create_user {
     }
     else {
         $r->{created} = 1;
-        my $default_time_allowance = $c->setting('DefaultTimeAllowance') || 0;
 
         $user = $user_rs->create(
             {
                 instance          => $instance,
                 username          => $username,
                 password          => $password,
-                minutes_allotment => $minutes || $default_time_allowance,
                 status            => 'enabled',
                 is_troublemaker   => 'No',
             }
         );
+
+        if (defined $minutes) {
+            $c->model('DB::Allotment')->update_or_create(
+                {
+                    instance => $user->instance,
+                    user_id  => $user->id,
+                    location => '',
+                    minutes  => $minutes,
+                }
+            );
+        }
     }
 
     if ( $admin || $superadmin ) {

--- a/root/dynamic/templates/administration/settings/index.tt
+++ b/root/dynamic/templates/administration/settings/index.tt
@@ -77,6 +77,12 @@
                              </div>
 
                             <div class="form-group">
+                                <input id="TimeAllowanceByLocation" name="TimeAllowanceByLocation" type="checkbox" [% IF TimeAllowanceByLocation %]checked="checked"[% END %]>
+                                <label for="TimeAllowanceByLocation">[% c.loc("Time allowance by location") %]</label>
+                                <small class="form-text text-muted">[% c.loc("If checked, each location has it's own time allowance shared between only the clients it contains.") %]</small>
+                            </div>
+
+                            <div class="form-group">
                                 <label for="TimeDisplayFormat" style="margin-bottom:3px">[% c.loc("Time display format") %]</label>
                                 <div>
                                     <input type="radio" id="12hour" name="TimeDisplayFormat" value="12" style="margin-left:15px;" [% IF Settings.TimeDisplayFormat == '12' %]checked[% END %]>

--- a/script/administration/create_user.pl
+++ b/script/administration/create_user.pl
@@ -41,11 +41,21 @@ else {
             instance          => $opt->instance,
             username          => $opt->username,
             password          => $opt->password,
-            minutes_allotment => $opt->minutes || $default_time_allowance,
             status          => 'enabled',
             is_troublemaker => 'No',
         }
     );
+
+    if (defined $opt->minutes) {
+        $c->model('DB::Allotment')->update_or_create(
+            {
+                instance => $user->instance,
+                user_id  => $user->id,
+                location => '',
+                minutes  => $opt->minutes,
+            }
+        );
+    }
 }
 
 if ( $opt->superadmin ) {

--- a/script/cronjobs/libki_nightly.pl
+++ b/script/cronjobs/libki_nightly.pl
@@ -25,7 +25,7 @@ $c->model('DB::User')->search( { is_guest => 'Yes' } )->delete();
 $c->model('DB::Setting')->search( { name => 'CurrentGuestNumber' } )->update( { value => '1' } );
 
 ## Reset user minutes
-$c->model('DB::User')->update( { minutes_allotment => undef } );
+$c->model('DB::Allotment')->delete();
 
 ## Set troublemaker status
 my @troublemakers = $c->model('DB::user')->search( { is_troublemaker => 'Yes' } );


### PR DESCRIPTION
Currently, all minutes spent during sessions are combined as a single total. This feature lets users have independent daily minutes per location. This means that all minutes used on clients in the same location will be grouped together, but without affecting other location's minutes.

To make this possible, the column "minutes_allotment" of the "users" database table has been transfered to a new table "allotments" to link daily minutes to both a user and a location.

This feature is off by default and is enabled from a system setting on the Libki server.

To test:
With the new preference TimeAllowanceByLocation set to off, there should be no change in functionnality. Login and minutes calculation while using the client, but also user creation and edition through the administration interface.
With the preference set to on:
    - login using clients from the same location should share the same daily minutes.
    - login with a client from another location should use different minutes. The number of daily minutes is the default for this location and minutes from location 1 won't decrease.
    - having only one location will behave the same way as having the preference set to off.
    - using an empty location still works.