### PR TITLE
Add ability to turn off, turn on or restart clients from the interface

### DIFF
--- a/lib/Libki/Clients.pm
+++ b/lib/Libki/Clients.pm
@@ -1,0 +1,68 @@
+package Libki::Clients;
+
+use Modern::Perl;
+use IO::Socket::INET;
+
+=head2 wakeonlan
+
+Send a magic packet for every MAC address in the ClientMACAddresses setting.
+
+=cut
+
+sub wakeonlan {
+    my ($c) = @_;
+
+    my $success = 1;
+
+    my $host = $c->setting('WOLHost') || '255.255.255.255';
+    my $port = $c->setting('WOLPort') || 9;
+    my $sockaddr = sockaddr_in($port, inet_aton($host));
+
+    my $mac_addresses_setting = $c->setting('ClientMACAddresses');
+    my @mac_addresses = split(/[\r\n]+/, $mac_addresses_setting);
+
+    foreach my $mac_address (@mac_addresses) {
+        my $socket = new IO::Socket::INET( Proto => 'udp' )
+            or $c->log()->fatal("ERROR in Socket Creation : $!\n");
+
+        if ($socket) {
+            $c->log()->debug("Sending magic packet to $mac_address at $host:$port");
+            $mac_address =~ s/://g;
+            my $packet = pack('C6H*', 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, $mac_address x 16);
+
+            setsockopt($socket, SOL_SOCKET, SO_BROADCAST, 1);
+            $success = 0 unless send($socket, $packet, 0, $sockaddr);
+            $socket->close;
+        } else {
+            $success = 0;
+        }
+    }
+
+    return $success;
+}
+
+=head1 AUTHOR
+
+Maryse Simard <maryse.simard@inlibro.com>
+
+=cut
+
+=head1 LICENSE
+This file is part of Libki.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut
+
+1;

--- a/lib/Libki/Controller/Administration/API/Client.pm
+++ b/lib/Libki/Controller/Administration/API/Client.pm
@@ -1,6 +1,7 @@
 package Libki::Controller::Administration::API::Client;
 use Moose;
 use namespace::autoclean;
+use Libki::Clients qw( wakeonlan );
 
 BEGIN { extends 'Catalyst::Controller'; }
 
@@ -346,6 +347,21 @@ sub restart_all : Local : Args(0) {
             $success = 1 if $client->update( { status => 'restart' } );
         }
     }
+
+    $c->stash( 'success' => $success );
+    $c->forward( $c->view('JSON') );
+}
+
+=head2 wakeup
+
+Wake up all clients using wake on lan.
+
+=cut
+
+sub wakeup : Local : Args(0) {
+    my ( $self, $c ) = @_;
+
+    my $success = Libki::Clients::wakeonlan($c);
 
     $c->stash( 'success' => $success );
     $c->forward( $c->view('JSON') );

--- a/root/dynamic/templates/administration/index.tt
+++ b/root/dynamic/templates/administration/index.tt
@@ -128,6 +128,7 @@
         <ul class="navbar-nav">
             <li class="nav-item">
                 <div class="btn-group" role="group" aria-label="Client actions">
+                    <a href="#" class="turn-on-button btn btn-success"><i class="fas fa-power-off"></i> [% c.loc("Turn on all clients") %]</a>
                     <a href="#" class="restart-button btn btn-warning"><i class="fas fa-redo"></i> [% c.loc("Restart all clients") %]</a>
                     <a href="#" class="shutdown-button btn btn-danger"><i class="fas fa-power-off"></i> [% c.loc("Turn off all clients") %]</a>
                 </div>
@@ -1238,6 +1239,19 @@ $(document).ready(function() {
     $('#multi-guest-modal-form-print').click(function(){
         var guestPassWindow = window.open();
         guestPassWindow.document.write(guest_pass_file_contents);
+    });
+
+    $(".turn-on-button").click(function () {
+        if ( confirm("[% c.loc("Are you sure you want to turn on all clients?") %]") ) {
+            $.getJSON( '[% c.uri_for('/administration/api/client/wakeup') %]', function(data) {
+                if ( data.success ) {
+                    DisplayMessage( "success", "[% c.loc("Clients turned on.") %]" );
+                    $("#client-table").dataTable().fnDraw(true);
+                } else {
+                    DisplayMessage( "error", "[% c.loc("Unable to turn on all clients.") %]" );
+                }
+            });
+        }
     });
 
     $(".shutdown-button").click(function () {

--- a/root/dynamic/templates/administration/index.tt
+++ b/root/dynamic/templates/administration/index.tt
@@ -122,6 +122,19 @@
         </ul>
 	</nav>
 
+    <nav class="navbar navbar-expand-lg navbar-light bg-none">
+        <ul class="navbar-nav mr-auto"></ul>
+
+        <ul class="navbar-nav">
+            <li class="nav-item">
+                <div class="btn-group" role="group" aria-label="Client actions">
+                    <a href="#" class="restart-button btn btn-warning"><i class="fas fa-redo"></i> [% c.loc("Restart all clients") %]</a>
+                    <a href="#" class="shutdown-button btn btn-danger"><i class="fas fa-power-off"></i> [% c.loc("Turn off all clients") %]</a>
+                </div>
+            </li>
+        </ul>
+    </nav>
+
         <table id="client-table" cellpadding="0" cellspacing="0" border="0" class="table table-striped table-bordered">
             <thead>
                 <th>[% c.loc("Name") %]</th>
@@ -158,6 +171,8 @@
                 <button id="client-table-row-toolbar-logout" class="btn libki-toolbar-btn btn-outline-danger" onclick="LibkiLogOutClient( window.selected_id )"><i class="fas fa-sign-out-alt"></i> [% c.loc("Log out") %]</button>
                 <button id="client-table-row-toolbar-status" class="btn libki-toolbar-btn btn-outline-secondary"><i class="fas fa-tag"></i> [% c.loc("Toggle status") %]</button>
                 <button id="client-table-row-toolbar-delete" class="btn libki-toolbar-btn btn-outline-danger" onclick="LibkiDeleteClient( window.selected_id )"><i class="fas fa-times"></i> [% c.loc("Delete") %]</button>
+                <button id="client-table-row-toolbar-restart" class="btn libki-toolbar-btn btn-outline-warning" onclick="LibkiRestartClient( window.selected_id )"><i class="fas fa-redo"></i> [% c.loc("Restart") %]</button>
+                <button id="client-table-row-toolbar-shutdown" class="btn libki-toolbar-btn btn-outline-danger" onclick="LibkiShutdownClient( window.selected_id )"><i class="fas fa-power-off"></i> [% c.loc("Turn off") %]</button>
             </div>
         </div>
   </div>
@@ -1225,6 +1240,31 @@ $(document).ready(function() {
         guestPassWindow.document.write(guest_pass_file_contents);
     });
 
+    $(".shutdown-button").click(function () {
+        if ( confirm("[% c.loc("Are you sure you want to turn off all clients?") %]") ) {
+            $.getJSON( '[% c.uri_for('/administration/api/client/shutdown_all') %]', function(data) {
+                if ( data.success ) {
+                    DisplayMessage( "success", "[% c.loc("Clients turned off.") %]" );
+                    $("#client-table").dataTable().fnDraw(true);
+                } else {
+                    DisplayMessage( "error", "[% c.loc("Unable to turn off all clients.") %]" );
+                }
+            });
+        }
+    });
+
+    $(".restart-button").click(function () {
+        if ( confirm("[% c.loc("Are you sure you want to restart all clients?") %]") ) {
+            $.getJSON( '[% c.uri_for('/administration/api/client/restart_all') %]', function(data) {
+                if ( data.success ) {
+                    DisplayMessage( "success", "[% c.loc("Clients restarted.") %]" );
+                    $("#client-table").dataTable().fnDraw(true);
+                } else {
+                    DisplayMessage( "error", "[% c.loc("Unable to restart all clients.") %]" );
+                }
+            });
+        }
+    });
 
     /*********** Users Table ***********/
     /* Edit User */
@@ -1605,6 +1645,32 @@ function LibkiUnlockClient( id ) {
          } else {
              DisplayMessage( "error", "[% c.loc("Unable to unlock client.") %]" );
          }
+     });
+  }
+}
+
+function LibkiShutdownClient( id ) {
+  if ( confirm("[% c.loc("Are you sure you want to turn off this client?") %]") ) {
+    $.getJSON( '[% c.uri_for('/administration/api/client/shutdown') %]' + '/' + id, function(data) {
+        if ( data.success ) {
+            DisplayMessage( "success", "[% c.loc("Client turned off.") %]" );
+            $("#client-table").dataTable().fnDraw(true);
+        } else {
+            DisplayMessage( "error", "[% c.loc("Unable to turn off client.") %]" );
+        }
+     });
+  }
+}
+
+function LibkiRestartClient( id ) {
+  if ( confirm("[% c.loc("Are you sure you want to restart this client?") %]") ) {
+    $.getJSON( '[% c.uri_for('/administration/api/client/restart') %]' + '/' + id, function(data) {
+        if ( data.success ) {
+            DisplayMessage( "success", "[% c.loc("Client restarted.") %]" );
+            $("#client-table").dataTable().fnDraw(true);
+        } else {
+            DisplayMessage( "error", "[% c.loc("Unable to restart client.") %]" );
+        }
      });
   }
 }

--- a/root/dynamic/templates/administration/settings/index.tt
+++ b/root/dynamic/templates/administration/settings/index.tt
@@ -547,6 +547,75 @@
                         <small class="form-text text-muted">[% c.loc("Automatically turn off clients this number of minutes after closing time. Leave empty to disable automatic shutdown.") %]</small>
                     </div>
                 </fieldset>
+
+                <fieldset>
+                    <legend>[% c.loc("Client power on settings") %]</legend>
+                    <small class="form-text text-muted">[% c.loc("To power on clients, wake on LAN must be enabled on the target computers. For more information, please refer to the Libki manual.") %]</small>
+                    <br/>
+
+                    <div class="form-group">
+                        <label for="WOLHost">[% c.loc("Host") %]</label>
+                        <div class="input-group">
+                            <input type="text" class="form-control" id="WOLHost" name="WOLHost" value="[% WOLHost %]">
+                        </div>
+                        <small class="form-text text-muted">[% c.loc("IP address or fully qualified domain name (FQDN) where to send the signal. Defaults to the limited broadcast address (255.255.255.255).") %]</small>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="WOLPort">[% c.loc("Port") %]</label>
+                        <div class="input-group">
+                            <input type="text" class="form-control" id="WOLPort" name="WOLPort" value="[% WOLPort %]">
+                        </div>
+                        <small class="form-text text-muted">[% c.loc("Port to send the signal. Defaults to the discard port (9).") %]</small>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="ClientMACAddresses">[% c.loc("MAC addresses") %]</label>
+                        <div class="input-group">
+                            <textarea class="form-control" id="ClientMACAddresses" name="ClientMACAddresses" rows="10">[% ClientMACAddresses %]</textarea>
+                        </div>
+                        <small class="form-text text-muted">[% c.loc("A list of the network adapter's MAC addresses for the computers to wake up.") %]</small>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="ClientWakeTime">[% c.loc("Automatic power on time") %]</label>
+                        <div class="input-group" style="width:200px;">
+					        <select id="ClientWakeHour" name="ClientWakeHour" class="form-control" style="width:50px;">
+                                <option value="" [% UNLESS ClientWakeHour %] selected="selected" [% END %]></option>
+						        [% FOREACH h IN Hours %]
+                                    [% IF h == 12 && TimeDisplayFormat == 12 %]
+                                        <optgroup label="-pm-"></optgroup>
+                                    [% END %]
+							            <option value="[% h %]" [% IF h == ClientWakeHour %] selected="selected" [% END %]>
+                                        [% IF TimeDisplayFormat == 12 %]
+                                            [% AM.$h %]
+                                        [% ELSE %]
+                                            [% h %]
+                                        [% END %]
+                                        </option>
+						        [% END %]
+					        </select>
+					        &nbsp;
+					        :
+					        &nbsp;
+                            [% SET Minutes = ['00','01','02','03','04','05','06','07','08','09','10','11','12','13','14','15','16','17','18','19','20','21','22','23','24','25','26','27','28','29','30','31','32','33','34','35','36','37','38','39','40','41','42','43','44','45','46','47','48','49','50','51','52','53','54','55','56','57','58','59'] %]
+					        <select id="ClientWakeMinute" name="ClientWakeMinute" class="form-control"  style="width:50px;">
+                                <option value="" [% UNLESS ClientWakeMinute %] selected="selected" [% END %]></option>
+						        [% FOREACH m IN Minutes %]
+							        <option value="[% m %]" [% IF m == ClientWakeMinute %] selected="selected" [% END %]>[% m %]</option>
+						        [% END %]
+					        </select>
+                            &nbsp;&nbsp;<a id="opening-ampm-label" style="visibility:[% IF TimeDisplayFormat == '12' %]visible[% ELSE %]hidden[% END %];">
+                                [% IF ClientWakeHour && ClientWakeHour > 11 %]
+                                    pm
+                                [% ELSE %]
+                                    am
+                                [% END %]
+                            </a>
+                        </div>
+                        <small class="form-text text-muted">[% c.loc("The time at which to automatically turn on the clients. Leave empty to disable.") %]</small>
+                    </div>
+                </fieldset>
             </div>
 
             <div class="tab-pane fade" id="v-pills-guest-passes" role="tabpanel" aria-labelledby="v-pills-guest-passes-tab">

--- a/root/dynamic/templates/administration/settings/index.tt
+++ b/root/dynamic/templates/administration/settings/index.tt
@@ -14,6 +14,7 @@
                     <a class="nav-link" id="v-pills-automatic-time-extension-tab" data-toggle="pill" href="#v-pills-automatic-time-extension" role="tab" aria-controls="v-pills-automatic-time-extension" aria-selected="false">[% c.loc("Automatic time extension") %]</a>
                     <a class="nav-link" id="v-pills-client-behavior-tab" data-toggle="pill" href="#v-pills-client-behavior" role="tab" aria-controls="v-pills-client-behavior" aria-selected="false">[% c.loc("Client behavior") %]</a>
                     <a class="nav-link" id="v-pills-client-login-banners-tab" data-toggle="pill" href="#v-pills-client-login-banners" role="tab" aria-controls="v-pills-client-login-banners" aria-selected="false">[% c.loc("Client login banners") %]</a>
+                    <a class="nav-link" id="v-pills-client-power-options-tab" data-toggle="pill" href="#v-pills-client-power-options" role="tab" aria-controls="v-pills-client-power-options" aria-selected="false">[% c.loc("Client power options") %]</a>
                     <a class="nav-link" id="v-pills-custom-javascript-tab" data-toggle="pill" href="#v-pills-custom-javascript" role="tab" aria-controls="v-pills-custom-javascript" aria-selected="false">[% c.loc("Custom JavaScript") %]</a>
                     <a class="nav-link" id="v-pills-data-retention-tab" data-toggle="pill" href="#v-pills-data-retention" role="tab" aria-controls="v-pills-data-retention" aria-selected="false">[% c.loc("Data retention") %]</a>
                     <a class="nav-link" id="v-pills-guest-passes-tab" data-toggle="pill" href="#v-pills-guest-passes" role="tab" aria-controls="v-pills-guest-passes" aria-selected="false">[% c.loc("Guest passes") %]</a>
@@ -517,6 +518,34 @@
                         </div>
                     </fieldset>
                     
+                </fieldset>
+            </div>
+
+            <div class="tab-pane fade" id="v-pills-client-power-options" role="tabpanel" aria-labelledby="v-pills-client-power-options-tab">
+                <fieldset>
+                    <legend>[% c.loc("Client power off settings") %]</legend>
+
+                    <div class="form-group">
+                        <label for="ClientShutdownAction" style="margin-bottom:3px">[% c.loc("Power off action") %]</label>
+                        <div>
+                            <input type="radio" id="shutdown" name="ClientShutdownAction" value="shutdown" style="margin-left:15px;" [% IF !ClientShutdownAction || ClientShutdownAction == 'shutdown' %]checked[% END %]>
+                            <label for="shutdown" style="margin-bottom:3px;"> Shutdown</label>
+                            <input type="radio" id="suspend" name="ClientShutdownAction" value="suspend" style="margin-left:20px;" [% IF ClientShutdownAction == 'suspend' %]checked[% END %]>
+                            <label for="suspend" style="margin-bottom:3px;"> Suspend</label>
+                            <small class="form-text text-muted" style="margin-top:0px">[% c.loc("Choose which action the automatic shutdown and turn off button perform. Depending on your setup, suspend may be necessary to correctly use together with the power on function.") %]</small>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="ClientShutdownDelay">[% c.loc("Client automatic shutdown delay") %]</label>
+                        <div class="input-group">
+                            <input type="text" class="form-control" id="ClientShutdownDelay" name="ClientShutdownDelay" value="[% ClientShutdownDelay %]">
+                            <div class="input-group-append">
+                                <span class="input-group-text">[% c.loc("Minutes") %]</span>
+                            </div>
+                        </div>
+                        <small class="form-text text-muted">[% c.loc("Automatically turn off clients this number of minutes after closing time. Leave empty to disable automatic shutdown.") %]</small>
+                    </div>
                 </fieldset>
             </div>
 

--- a/script/cronjobs/libki.pl
+++ b/script/cronjobs/libki.pl
@@ -248,6 +248,15 @@ foreach my $instance ( @instances ) {
     }
 }
 
+## automatic power on
+my $wake_hour = $c->setting('ClientWakeHour');
+if ( $wake_hour || DateTime->now( time_zone => $ENV{LIBKI_TZ} )->hour == $wake_hour ) {
+    my $wake_minutes = $c->setting('ClientWakeMinute') || 0;
+    if ( DateTime->now( time_zone => $ENV{LIBKI_TZ} )->minute == $wake_minutes ) {
+        Libki::Clients::wakeonlan($c);
+    }
+}
+
 =head1 AUTHOR
 
 Kyle M Hall <kyle@kylehall.info> 


### PR DESCRIPTION
Add actions in the interface to control power state of the clients from the administration interface. A user can shutdown or restart all or specific clients. Automatic shutdown lets administrators choose to automatically shutdown all of the computers x minutes after closing time.

The computers can also be turned on using the wake on LAN protocol. Options are available in the settings menu to setup the functionality. A list of MAC addresses can be set up to wake all of the computer at once. The ability to wake up single computers, as can be done with shutdown, is not available. Automatic wake up is also possible, but is set as a single time and don't depend on opening times or location.

By default, wake on LAN operates on the local network (with the server and clients belonging to the same network), using the limited broadcast address if no IP address is set in the settings. It is possible to implement it on distant network by forwarding requests to the broadcast address either via port forwarding at the router level or via a forwarding service running on a dedicated machine.
Please see the corresponding patch in the manual for more details about the new settings.


To test shutdown/restart, you need a client with the corresponding patch applied. Buttons to shutdown and restart all or individual clients can be tested and automatic shutdown can be set to turn off all clients after a location's closing time. Either with the button or automatic shutdown, the value of the "Power off action" setting should be respected.

To test waking up the clients, wake on LAN must first be enabled on the client machines. From the server, one can turn on all the computer at once either with the button "Turn on all clients" or automatically at the time given in the "Automatic power on time" setting. The "MAC addresses" setting must be filled for the action to work.