### PR TITLE
Issue 177: Missing quotes break javascript in TranslateStatus function

### DIFF
--- a/root/dynamic/templates/administration/index.tt
+++ b/root/dynamic/templates/administration/index.tt
@@ -1499,7 +1499,7 @@ $(document).ready(function() {
         return status == 'suspended' ? '[% c.loc("Suspended") %]' : 
                status == 'offline'   ? '[% c.loc("Offline") %]'   :
                status == 'online'    ? '[% c.loc("Online") %]'    :
-               [% c.loc("Unknown") %];
+               '[% c.loc("Unknown") %]';
     }
 
     /* Make reservation */


### PR DESCRIPTION
This should take care of issue 177. When status is "Unknown", missing quotes break the javascript. This happens when status is set to "unlock" while unlocking. Since "unlock" status only serves as signal and as no real meaning for the user, I chose not to add a description for it.