### PR TITLE
Add the possibility to use the client for sending wake on LAN packets

### DIFF
--- a/lib/Libki/Controller/API/Client/v1_0.pm
+++ b/lib/Libki/Controller/API/Client/v1_0.pm
@@ -80,6 +80,17 @@ sub index : Path : Args(0) {
             $c->stash(
                 $client_s->status => 1,
             );
+        } elsif ($client_s->status eq "wakeup") {
+            my $host = $c->setting('WOLHost') || '255.255.255.255';
+            my $port = $c->setting('WOLPort') || 9;
+            my @mac_addresses = split(/[\r\n]+/, $c->setting('ClientMACAddresses'));
+
+            $c->stash(
+                wakeup => 1,
+                wol_host => $host,
+                wol_port => $port,
+                wol_mac_addresses => \@mac_addresses,
+            );
         }
 
         my $minutes_to_shutdown = $c->setting('ClientShutdownDelay');

--- a/root/dynamic/templates/administration/settings/index.tt
+++ b/root/dynamic/templates/administration/settings/index.tt
@@ -571,6 +571,17 @@
                     <br/>
 
                     <div class="form-group">
+                        <label for="WOLMode" style="margin-bottom:3px">[% c.loc("Send the signal using") %]</label>
+                        <div>
+                            <input type="radio" id="wol-server" name="WOLMode" value="server" style="margin-left:15px;" [% IF !WOLMode || WOLMode == 'server' %]checked[% END %]>
+                            <label for="server" style="margin-bottom:3px;"> [% c.loc("the server") %]</label>
+                            <input type="radio" id="wol-client" name="WOLMode" value="client" style="margin-left:20px;" [% IF WOLMode == 'client' %]checked[% END %]>
+                            <label for="client" style="margin-bottom:3px;"> [% c.loc("the client") %]</label>
+                            <small class="form-text text-muted" style="margin-top:0px">[% c.loc("When using the client, at least one Libki client must be running at the time when the wake up signal is received.") %]</small>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
                         <label for="WOLHost">[% c.loc("Host") %]</label>
                         <div class="input-group">
                             <input type="text" class="form-control" id="WOLHost" name="WOLHost" value="[% WOLHost %]">


### PR DESCRIPTION
This enhancement was prompted by our need to use wake on LAN capabilities on a distant network. In this scenario, a single running client could trigger the waking of all the other machines without needing the server to directly access the network.

This uses client registering to send the necessary informations (mac addresses, host and port) when the new setting is set to "client". The default value of "server" uses current behavior.

The corresponding patch for the client is necessary.

As long as the new setting is set to "server", the wake on LAN behavior should remain unchanged.
If set to "client", the same result should be observed on the condition that a client is running. If no clients are opened, wake on LAN won't work.