### PR TITLE
Update guest pass printing

### DIFF
--- a/root/dynamic/templates/administration/index.tt
+++ b/root/dynamic/templates/administration/index.tt
@@ -1203,6 +1203,7 @@ $(document).ready(function() {
             myWindow.focus();
             myWindow.print();
             myWindow.close();
+            location.reload(); 
           });
 
         $('#new-guest-modal').modal();


### PR DESCRIPTION
Page need to be refreshed after creating guest pass to prevent printing out old guest passes.