### PR TITLE
installer/updater run on Ubuntu 20.04 fails to create logs table:

### DIFF
--- a/installer/versions/4/0.7_add_logs_table.sql
+++ b/installer/versions/4/0.7_add_logs_table.sql
@@ -5,7 +5,7 @@ CREATE TABLE `logs` (
   `pid` varchar(10) NOT NULL default '',
   `hostname` varchar(100) NOT NULL default '',
   `level` varchar(10) NOT NULL default '',
-  `message` text NOT NULL default '',
+  `message` text NOT NULL,
   PRIMARY KEY  (`id`),
   KEY `created_on_idx` (`created_on`)
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;


### PR DESCRIPTION
Updating or installing on Ubuntu 20.04 results in the following error:

```
UPDATE FAILED IN FILE /home/libki/libki-server/installer/versions/4/0.7_add_logs_table.sql: main::try {...} (): DBI Exception: DBD::mysql::db do failed: BLOB, TEXT, GEOMETRY or JSON column 'message' can't have a default value [for Statement "CREATE TABLE `logs` (
  `id` int(11) NOT NULL auto_increment,
  `instance` varchar(32) NULL DEFAULT '',
  `created_on` datetime NOT NULL default CURRENT_TIMESTAMP,
  `pid` varchar(10) NOT NULL default '',
  `hostname` varchar(100) NOT NULL default '',
  `level` varchar(10) NOT NULL default '',
  `message` text NOT NULL default '',
  PRIMARY KEY  (`id`),
  KEY `created_on_idx` (`created_on`)
) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci"] at /home/libki/libki-server/installer/update_db.pl line 94
```
Removing the "default ''" from the message text line resolves the
problem.