### PR TITLE
Checks for redirect to login in ajax calls and reload page accordingly

### DIFF
--- a/root/dynamic/includes/wrapper.tt
+++ b/root/dynamic/includes/wrapper.tt
@@ -100,6 +100,17 @@
     <script type="text/javascript">
         [% IF interface == 'administration' %]
             [% CustomJsAdministration %]
+
+            $(document).ajaxComplete(function(event, request, options) {
+                var contenttype = request.getResponseHeader('content-type');
+                if (contenttype && contenttype.match(/^text\/html/)) {
+                    if (request.responseText.match(/login[-]form/)) {   // character class stops regex from matching itself
+                        $(".alert-success").remove();   // removes displayed success messages which could be misleading
+                        DisplayMessage( "error", "[% c.loc("You've been logged out.") %]" );
+                        window.location.reload();
+                    }
+                }
+            });
         [% ELSE %]
             [% CustomJsPublic %]
         [% END %]

--- a/root/dynamic/templates/login.tt
+++ b/root/dynamic/templates/login.tt
@@ -1,7 +1,7 @@
 [% meta.title = c.loc("Log in") %]
 
 <div class="container">
-<form class="form-horizontal" role="form" method="POST" action="[% c.uri_for('/administration/login') %]">
+<form id="login-form" class="form-horizontal" role="form" method="POST" action="[% c.uri_for('/administration/login') %]">
     <div class="row">
         <div class="col-md-3"></div>
         <div class="col-md-6">


### PR DESCRIPTION
When a user is connected to the administration interface, they will be redirected automatically to the login screen upon visiting a new page if their session expires. However, if the user doesn't navigate away from the page they won't be redirected, which can be problematic for asynchronous javascript.

In most cases, this is not critical (datatables stuck on "Processing..." or vague error messages), but in some cases it can cause problems. For example, when updating settings in Administration/Settings the ajax succeeds (the redirection to the login page returns a success) and the "settings updated" message is shown, which is wrong.

This adds a check to ajax calls to test if returned data is html (more specifically the login form) and reloads to page, which will then cause a redirect to the login.