### PR TITLE
Move automatic power off to cronjob

### DIFF
--- a/lib/Libki/Controller/API/Client/v1_0.pm
+++ b/lib/Libki/Controller/API/Client/v1_0.pm
@@ -95,17 +95,6 @@ sub index : Path : Args(0) {
             );
         }
 
-        my $minutes_to_shutdown = $c->setting('ClientShutdownDelay');
-        if (length($minutes_to_shutdown)) {
-            my $minutes_until_closing = Libki::Hours::minutes_until_closing({ c => $c, location => $client_s->location });
-            if ( defined $minutes_until_closing && ($minutes_until_closing + $minutes_to_shutdown) < 0 ) {
-                my $status  = $c->setting('ClientShutdownAction') || 'shutdown';
-                $c->stash(
-                    $status => 1,
-                );
-            }
-        }
-
         $client_s->update( { status => 'online' } ) if ( $client_s->status ne 'suspended' );
         $log->debug( "Client Registered: " . $client->name() );
 


### PR DESCRIPTION
When using automatic power off (Administration > Settings > Client power off options), once the shutdown delay has been reached for the day it becomes impossible to start the client again. The computer will be shutdown again the next time the client registers.

This moves the automatic power off logic to the libki.pl cronjob so the shutdown is only triggered once, when the exact delay is reached.