### PR TITLE
Libki wrongly alerts patrons that they have waiting holds if used wit…

### DIFF
--- a/libki_local.conf.example
+++ b/libki_local.conf.example
@@ -32,4 +32,5 @@
                                                             # Leave EXPIRED_CARD unchanged
     category_field PC          # Category field in SIP response
     pattern_personal_name ,    # Pattern for spliting lastname et firstname in personal name field(AE) in SIP response
+    ILS Koha                   # Options are currently 'Koha' and 'Evergreen', defaults to Koha behavior
 </SIP>


### PR DESCRIPTION
…h Evergreen ILS via SIP #245

If using SIP integration with the Evergreen ILS, Libki client tells the patron they have holds waiting if they have holds that are not yet waiting.

Patron should be alerted to waiting holds if they have actual waiting holds.

The issue here is that Koha and Evergreen use the "holds items count" and "unavailable holds count" SIP fields differently. Koha puts waiting holds in the former and non-waiting holds in the latter. Evergreen puts all holds in the former and non-waiting holds in the latter. This means for Evergreen we have to calculate the waiting holds count by subtracting the unavailable holds count from the hold items count.