### PR TITLE
Move metrics endpoint to custom controller

### DIFF
--- a/lib/Libki.pm
+++ b/lib/Libki.pm
@@ -84,6 +84,7 @@ __PACKAGE__->config(
 
 mkdir('/dev/libki_metrics'); # /dev is a ram disk, use for storing prom metrics
 __PACKAGE__->config('Plugin::PrometheusTiny' => {
+    no_default_controller => 1,
     filename => -w '/dev/libki_metrics' ? '/dev/libki_metrics' : '/tmp/libki_metrics',
     metrics => {
         active_clients => {

--- a/lib/Libki/Controller/Metrics.pm
+++ b/lib/Libki/Controller/Metrics.pm
@@ -1,0 +1,74 @@
+package Libki::Controller::Metrics;
+use Moose;
+use namespace::autoclean;
+
+BEGIN { extends 'Catalyst::Controller'; }
+
+use Encode qw(decode);
+
+=head1 NAME
+
+Libki::Controller::Metrics - Catalyst Controller for Prometheus Metrics
+
+=head1 DESCRIPTION
+
+Catalyst Controller.
+
+=head1 METHODS
+
+=cut
+
+=head2 begin
+
+=cut
+
+sub begin : Private { }
+
+=head2 end
+
+=cut
+
+sub end  : Private  { }
+
+=head2 index
+
+=cut
+
+sub index : Path Args(0) {
+    my ( $self, $c ) = @_;
+    $c->prometheus->set( 'active_clients', $c->model('DB::Client')->search( { status => 'online' } )->count() );
+    $c->prometheus->set( 'active_sessions', $c->model('DB::Session')->count() );
+
+    my $res = $c->res;
+    $res->content_type("text/plain");
+    $res->output( $c->prometheus->format );
+}
+
+=head1 AUTHOR
+
+Kyle M Hall <kyle@kylehall.info>
+
+=cut
+
+=head1 LICENSE
+
+This file is part of Libki.
+
+Libki is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as 
+published by the Free Software Foundation, either version 3 of
+the License, or (at your option) any later version.
+
+Libki is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Libki.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/script/cronjobs/libki.pl
+++ b/script/cronjobs/libki.pl
@@ -37,13 +37,6 @@ $c->model('DB::Log')->create(
     }
 );
 
-$c->prometheus->set(
-    'active_clients', $c->model('DB::Client')->search( { status => 'online' } )->count()
-);
-$c->prometheus->set(
-    'active_sessions', $c->model('DB::Session')->count()
-);
-
 my $lang = 'en';
 if ( $c->installed_languages()->{$lang} ) {
     $c->session->{lang} = $lang;


### PR DESCRIPTION
Moving metrics to a custom controller
A) Fixes the crash on a fresh database install
B) Allows us to gather guage counts in realtime instead of in the cronjob