### PR TITLE
Users cannot be deleted from the staff interface #259

### DIFF
--- a/lib/Libki/Controller/Administration/API/User.pm
+++ b/lib/Libki/Controller/Administration/API/User.pm
@@ -8,6 +8,8 @@ use POSIX;
 
 use Libki::Utils::Printing;
 
+use JSON qw(to_json);
+
 BEGIN { extends 'Catalyst::Controller'; }
 
 =head1 NAME


### PR DESCRIPTION
**Describe the bug**
Undefined subroutine &Libki::Controller::Administration::API::User::to_json called at /app/lib/Libki/Controller/Administration/API/User.pm line 376. at /app/lib/Libki/Controller/Administration/API/User.pm line 394

**To Reproduce**
Steps to reproduce the behavior:
1. Log into the staff interface
2. Attempt to delete a user