### PR TITLE
Add ability to specify if personal names in SIP come in reserse order…

### DIFF
--- a/lib/Libki/SIP.pm
+++ b/lib/Libki/SIP.pm
@@ -241,6 +241,8 @@ sub authenticate_via_sip {
         = split( $c->config->{SIP}->{pattern_personal_name}, $sip_fields->{AE} );
     $lastname  =~ s/^\s+//;
     $firstname =~ s/^\s+//;
+    ( $lastname, $firstname ) = ( $firstname, $lastname ) if $c->config->{SIP}->{pattern_personal_name_reverse};
+
     my $category = $sip_fields->{ $c->config->{SIP}->{category_field} };
     $c->add_user_category($category) if $category;
 

--- a/libki_local.conf.example
+++ b/libki_local.conf.example
@@ -32,5 +32,6 @@
                                                             # Leave EXPIRED_CARD unchanged
     category_field PC          # Category field in SIP response
     pattern_personal_name ,    # Pattern for spliting lastname et firstname in personal name field(AE) in SIP response
+    pattern_personal_name_reverse: 1 # If the names are ordered firstname then lastname, enable this option
     ILS Koha                   # Options are currently 'Koha' and 'Evergreen', defaults to Koha behavior
 </SIP>


### PR DESCRIPTION
… #264

Libki's SIP integration assumes personal names come in the order last name, then first name. Some SIP servers send the name in the order first name, last name. Libki should be able to handle this.

To enable this option, set the new SIP config option 'pattern_personal_name_reverse' to a true value.