### PR TITLE
Add session_id to deleted session stats

### DIFF
--- a/script/cronjobs/libki.pl
+++ b/script/cronjobs/libki.pl
@@ -87,6 +87,7 @@ foreach my $s (@$sessions_to_delete) {
             client_name => $s->{name},
             action      => 'SESSION_DELETED',
             created_on  => $when,
+            session_id  => $s->{session_id},
         }
     );
 }


### PR DESCRIPTION
Our reporting requires us to calculate public computer usage by time. Currently we use queries to work out the time between session start and session finish by session_id. 
If a session is deleted there is no session_id logged in the statistics. 
By adding this we are able to calculate the finish time on sessions that are deleted as well.
