### PR TITLE
Prevent API error if user is invalid #368

### DIFF
--- a/lib/Libki/Controller/API/Client/v1_0.pm
+++ b/lib/Libki/Controller/API/Client/v1_0.pm
@@ -489,6 +489,10 @@ sub index : Path : Args(0) {
             }
         }
         elsif ( $action eq 'get_user_data' ) {
+            unless ( $user ) {
+                $c->response->body('User not found');
+                $c->response->status(404);
+            }
 
             my $status;
             if ( $user->session ) {
@@ -514,6 +518,11 @@ sub index : Path : Args(0) {
             $user->messages()->delete();
         }
         elsif ( $action eq 'logout' ) {
+            unless ( $user ) {
+                $c->response->body('User not found');
+                $c->response->status(404);
+            }
+
             my $session    = $user->session;
 
             if ($session) {


### PR DESCRIPTION
Errors like:
Caught exception in Libki::Controller::API::Client::v1_0->index "Can't call method "session" on an undefined value at /app/lib/Libki/Controller/API/Client/v1_0.pm line 517." will occur if the username provided doesn't match an existing user.

We should return a 404 if the user is not found.