### PR TITLE
Fix missing parameter to call to get_wol_mac_addresses for WOL featur…

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -20,7 +20,7 @@ jobs:
       run: docker save libki-server > ${{ github.sha }}.debian.tar
 
     - name: Upload image artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ github.sha }}.debian.tar
         path: ${{ github.sha }}.debian.tar
@@ -32,7 +32,7 @@ jobs:
     steps:
 
     - name: Download image artifact
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: ${{ github.sha }}.debian.tar
         path: /tmp
@@ -84,7 +84,7 @@ jobs:
       run: docker save libki-server > ${{ github.sha }}.alpine.tar
 
     - name: Upload image artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ github.sha }}.alpine.tar
         path: ${{ github.sha }}.alpine.tar
@@ -100,7 +100,7 @@ jobs:
         fetch-depth: 1
 
     - name: Download image artifact
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: ${{ github.sha }}.alpine.tar
         path: /tmp

--- a/lib/Libki/Clients.pm
+++ b/lib/Libki/Clients.pm
@@ -18,7 +18,7 @@ sub wakeonlan {
     my $port = $c->setting('WOLPort') || 9;
     my $sockaddr = sockaddr_in($port, inet_aton($host));
 
-    my @mac_addresses = get_wol_mac_addresses();
+    my @mac_addresses = get_wol_mac_addresses($c);
 
     foreach my $mac_address (@mac_addresses) {
         my $socket = new IO::Socket::INET( Proto => 'udp' )

--- a/lib/Libki/Clients.pm
+++ b/lib/Libki/Clients.pm
@@ -11,7 +11,6 @@ Send a magic packet for every MAC address in the ClientMACAddresses setting.
 
 sub wakeonlan {
     my ($c) = @_;
-
     my $success = 1;
 
     my $host     = $c->setting('WOLHost') || '255.255.255.255';
@@ -21,9 +20,12 @@ sub wakeonlan {
     my @mac_addresses = get_wol_mac_addresses($c);
 
     my $socket = new IO::Socket::INET( Proto => 'udp' )
-        or $c->log()->fatal("ERROR in Socket Creation : $!\n");
+        or do {
+        $c->log()->error("Socket Creation failed: $!\n");
+        $success = 0;
+        };
 
-    if ($socket) {
+    if ( $success && $socket ) {
         setsockopt( $socket, SOL_SOCKET, SO_BROADCAST, 1 );
 
         foreach my $mac_address (@mac_addresses) {

--- a/lib/Libki/Clients.pm
+++ b/lib/Libki/Clients.pm
@@ -24,12 +24,13 @@ sub wakeonlan {
         or $c->log()->fatal("ERROR in Socket Creation : $!\n");
 
     if ($socket) {
+        setsockopt( $socket, SOL_SOCKET, SO_BROADCAST, 1 );
+
         foreach my $mac_address (@mac_addresses) {
             $c->log()->debug("Sending magic packet to $mac_address at $host:$port");
             $mac_address =~ s/://g;
             my $packet = pack( 'C6H*', 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, $mac_address x 16 );
 
-            setsockopt( $socket, SOL_SOCKET, SO_BROADCAST, 1 );
             $success = 0 unless send( $socket, $packet, 0, $sockaddr );
             $socket->close;
         }


### PR DESCRIPTION
…e #402

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a missing parameter `$c` to the function call of `get_wol_mac_addresses` and refactor socket initialization to occur outside of the loop for sending WOL magic packets.

### Why are these changes being made?

The missing argument `$c` was causing function call errors for `get_wol_mac_addresses`, likely resulting in unexpected behavior when attempting to retrieve MAC addresses. Refactoring the socket initialization to occur once before the loop improves the efficiency of network operations in the wake-on-LAN feature by eliminating redundant socket creations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->