### PR TITLE
Update History.pm

### DIFF
--- a/lib/Libki/Controller/Administration/History.pm
+++ b/lib/Libki/Controller/Administration/History.pm
@@ -119,7 +119,8 @@ sub statistics : Local : Args(0) {
             ],
             as       => [ 'name', 'count', 'location', ],
             group_by => [
-                'client_name'
+                'client_name',
+                'client_location'
             ],
         }
     );


### PR DESCRIPTION
Added 'client_location' to the group_by sql script for the statistics page.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the statistics query to group results by both client_name and client_location (previously only client_name).

### Why are these changes being made?
Enhances granularity of statistics by including client location in the grouping, providing more precise counts.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->