### PR TITLE
Change auto_release to include options to only auto-release jobs from…

### DIFF
--- a/lib/Libki/Utils/Printing.pm
+++ b/lib/Libki/Utils/Printing.pm
@@ -124,7 +124,7 @@ sub create_print_job_and_file {
             );
         }
 
-        if ( $print_job
+        if ( $print_job && $printer->{auto_release}
             && (  $printer->{auto_release} eq 'yes'
                 || ( $printer->{auto_release} eq 'client' && $client_name ne PRINT_FROM_WEB ) 
                 || ( $printer->{auto_release} eq 'public' && $client_name eq PRINT_FROM_WEB ) 


### PR DESCRIPTION
… client or from public. Closes #434 

Changes the existing auto_release parameter in the printer configuration YAML to have three valid values:

- 'yes' - existing behavior, allows this printer to auto-release all jobs
- 'client' - only auto-release jobs sent from a client PC
- 'public' - only auto-release jobs uploaded from the public server interface