### PR TITLE
Require Net::LDAP before using it.

### DIFF
--- a/lib/Libki/LDAP.pm
+++ b/lib/Libki/LDAP.pm
@@ -133,10 +133,6 @@ sub testGuid {
     my $ldaps = shift;
     my $match_attribute = shift;
 
-    my $userDn = getUserDn($guid, $adminDn, $adminPwd, $searchBase, $host, $port, $ldaps, $match_attribute );
-
-    return undef unless $userDn;
-    
     if ($ldaps) {
         require Net::LDAPS;
         $ldap = Net::LDAPS->new($host, verify=>'none') or die "$@";
@@ -145,6 +141,10 @@ sub testGuid {
         $ldap = Net::LDAP->new($host, verify=>'none') or die "$@";    
     }
 
+    my $userDn = getUserDn($guid, $adminDn, $adminPwd, $searchBase, $host, $port, $ldaps, $match_attribute );
+
+    return undef unless $userDn;
+    
     my $mesg = $ldap->bind ($userDn, password=>"$userPwd");
     
     if ($mesg->code) {


### PR DESCRIPTION
Currently, the `require Net::LDAP` and `require Net::LDAPS` statements occur after `Net::LDAP` is used in the `getUserDn()` subroutine. Moving the require lines up resolves this.