### PR TITLE
Fix regex for print file name validation

### DIFF
--- a/lib/Libki/Controller/API/Client/v1_0.pm
+++ b/lib/Libki/Controller/API/Client/v1_0.pm
@@ -666,7 +666,8 @@ sub print : Path('print') : Args(0) {
     if ( $client && $user ) {
         my $print_file = $c->req->upload('print_file');
 
-        $print_file->filename =~ m/[a-zA-z]*(\d+)_(\d+)\.[a-zA-Z]+/;
+        # expected pattern is <documentname><someconstantchar><copies>_<somenumber>.<fileextension>
+        $print_file->filename =~ m/[a-zA-z]+(\d+)_(\d+)\.[a-zA-Z]+$/;
         my $copies = $1 || 1;
 
         Libki::Utils::Printing::create_print_job_and_file(


### PR DESCRIPTION
Updated regex pattern to match print file names correctly.  Anchored to end of the string, and made sure we match at least one character before the pattern match